### PR TITLE
Add saved queries page

### DIFF
--- a/ts/app.ts
+++ b/ts/app.ts
@@ -6,6 +6,7 @@ import { routes } from "./router";
 import { segmentPage, segmentsPage } from "./segment-page";
 import { settingsPage } from "./settings";
 import { Container } from "./ui";
+import { queriesPage } from "./queries";
 
 window.onload = () => {
 	const body = document.querySelector("body");
@@ -17,8 +18,9 @@ window.onload = () => {
 		"/tests/logs": () => logtableTest(body),
 		"/settings": () => settingsPage(container),
 		"/devices": () => devicesPage(body),
-		"/segments": () => segmentsPage(container),
-		"/segment/:segmentId": (params: any) => segmentPage(body, params.segmentId),
+               "/segments": () => segmentsPage(container),
+               "/queries": () => queriesPage(body),
+               "/segment/:segmentId": (params: any) => segmentPage(body, params.segmentId),
 		"/pivot": () => PivotPage(body),
 		"/*": () => mainPage(body)
 	})

--- a/ts/logs.ts
+++ b/ts/logs.ts
@@ -2,6 +2,7 @@ import { showModal } from "./common"
 import { formatLogMsg } from "./logmsg"
 import { navigate } from "./router"
 import { Button } from "./ui"
+import { saveQuery } from "./queries"
 import { getQueryParam, removeQueryParam, setQueryParam } from "./utility"
 
 export type LogLevel = 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'fatal'
@@ -85,14 +86,23 @@ export const logsSearchPage = (args: LogsSearchPageArgs) => {
 	optionsRightPanel.className = "logs-options-right-panel"
 	logsOptions.appendChild(optionsRightPanel)
 
-	const settingsButton = document.createElement("button")
-	settingsButton.innerHTML = settingsSvg
-	settingsButton.onclick = () => navigate("/settings")
+    const settingsButton = document.createElement("button")
+    settingsButton.innerHTML = settingsSvg
+    settingsButton.onclick = () => navigate("/settings")
 
-	const searchButton = document.createElement("button")
-	searchButton.innerHTML = searchSvg
+    const saveButton = document.createElement("button")
+    saveButton.textContent = "Save"
+    saveButton.onclick = () => {
+            const query = searchTextarea.value.trim()
+            if (!query) return
+            const name = prompt("Query name", query)
+            if (name) saveQuery({ name, query })
+    }
 
-	optionsRightPanel.append(settingsButton, searchButton)
+    const searchButton = document.createElement("button")
+    searchButton.innerHTML = searchSvg
+
+    optionsRightPanel.append(settingsButton, saveButton, searchButton)
 	const logsList = document.createElement("div")
 	logsList.className = "logs-list"
 	args.root.appendChild(logsList)

--- a/ts/queries.ts
+++ b/ts/queries.ts
@@ -1,0 +1,44 @@
+import { Header } from "./ui";
+import { navigate } from "./router";
+
+export type SavedQuery = {
+        name: string
+        query: string
+}
+
+export const loadSavedQueries = (): SavedQuery[] => {
+        try {
+                const raw = localStorage.getItem("savedQueries")
+                if (!raw) return []
+                return JSON.parse(raw) as SavedQuery[]
+        } catch {
+                return []
+        }
+}
+
+export const saveQuery = (item: SavedQuery) => {
+        const items = loadSavedQueries()
+        items.push(item)
+        localStorage.setItem("savedQueries", JSON.stringify(items))
+}
+
+export const queriesPage = (root: HTMLElement) => {
+        root.innerHTML = ""
+        const header = new Header({ title: "Saved Queries" })
+        root.appendChild(header.root)
+        const list = document.createElement("div")
+        list.style.display = "flex"
+        list.style.flexDirection = "column"
+        list.style.gap = "10px"
+        list.style.padding = "16px"
+        root.appendChild(list)
+        const items = loadSavedQueries()
+        items.forEach(item => {
+                const row = document.createElement("div")
+                row.className = "list-row"
+                row.textContent = item.name
+                row.onclick = () => navigate(`/?query=${encodeURIComponent(item.query)}`)
+                list.appendChild(row)
+        })
+        return root
+}

--- a/ts/settings.ts
+++ b/ts/settings.ts
@@ -27,10 +27,11 @@ class LinkList extends UiComponent<HTMLDivElement> {
 
 export const settingsPage = (root: Container) => {
 	root.root.innerHTML = ""
-	const linkList = new LinkList([
-		{ href: "/logs", text: "Logs" },
-		{ href: "/devices", text: "Devices" },
-		{ href: "/segments", text: "Segments" },
-	])
+        const linkList = new LinkList([
+                { href: "/logs", text: "Logs" },
+                { href: "/devices", text: "Devices" },
+                { href: "/segments", text: "Segments" },
+                { href: "/queries", text: "Saved Queries" },
+        ])
 	root.add(linkList)
 }


### PR DESCRIPTION
## Summary
- allow saving log queries from the Logs page
- add `/queries` page to view saved log queries
- link Saved Queries from settings and router
- include compiled JS bundle

## Testing
- `cargo test --workspace --frozen --offline`