### PR TITLE
Add timezone offset support

### DIFF
--- a/assets/puppylog.js
+++ b/assets/puppylog.js
@@ -1157,6 +1157,7 @@ var logsSearchPage = (args) => {
     if (searchTextarea.value)
       params.set("query", searchTextarea.value);
     params.set("bucketSecs", "60");
+    params.set("tzOffset", new Date().getTimezoneOffset().toString());
     const url = new URL("/api/v1/logs/histogram", window.location.origin);
     url.search = params.toString();
     const es = new EventSource(url);
@@ -1437,6 +1438,7 @@ var mainPage = (root) => {
         streamQuery.append("count", args.count.toString());
       if (args.endDate)
         streamQuery.append("endDate", args.endDate);
+      streamQuery.append("tzOffset", new Date().getTimezoneOffset().toString());
       const streamUrl = new URL("/api/logs", window.location.origin);
       streamUrl.search = streamQuery.toString();
       const eventSource = new EventSource(streamUrl);

--- a/core/src/query_eval.rs
+++ b/core/src/query_eval.rs
@@ -1,5 +1,4 @@
-use chrono::Datelike;
-use chrono::Timelike;
+use chrono::{Datelike, FixedOffset, Timelike};
 
 use crate::query_parsing::Condition;
 use crate::query_parsing::Expr;
@@ -817,12 +816,18 @@ mod tests {
 	fn test_empty_and_value_expressions() {
 		let log = create_test_log_entry();
 
-		assert!(check_expr(&Expr::Empty, &log).unwrap());
-		assert!(check_expr(&Expr::Value(Value::String("nonempty".to_string())), &log).unwrap());
-		assert!(!check_expr(&Expr::Value(Value::String("".to_string())), &log).unwrap());
-		assert!(check_expr(&Expr::Value(Value::Number(1)), &log).unwrap());
-		assert!(!check_expr(&Expr::Value(Value::Number(0)), &log).unwrap());
-		assert!(check_expr(&Expr::Value(Value::Date(Utc::now())), &log).unwrap());
+		let tz = chrono::FixedOffset::east_opt(0).unwrap();
+		assert!(check_expr(&Expr::Empty, &log, &tz).unwrap());
+		assert!(check_expr(
+			&Expr::Value(Value::String("nonempty".to_string())),
+			&log,
+			&tz
+		)
+		.unwrap());
+		assert!(!check_expr(&Expr::Value(Value::String("".to_string())), &log, &tz).unwrap());
+		assert!(check_expr(&Expr::Value(Value::Number(1)), &log, &tz).unwrap());
+		assert!(!check_expr(&Expr::Value(Value::Number(0)), &log, &tz).unwrap());
+		assert!(check_expr(&Expr::Value(Value::Date(Utc::now())), &log, &tz).unwrap());
 	}
 
 	#[test]

--- a/core/src/query_parsing.rs
+++ b/core/src/query_parsing.rs
@@ -1,5 +1,5 @@
 use crate::LogEntry;
-use chrono::{DateTime, NaiveDate, Utc};
+use chrono::{DateTime, FixedOffset, NaiveDate, Utc};
 use serde::de::value;
 use std::str::FromStr;
 
@@ -80,11 +80,15 @@ pub struct QueryAst {
 	pub limit: Option<usize>,
 	pub offset: Option<usize>,
 	pub end_date: Option<DateTime<Utc>>,
+	pub tz_offset: Option<chrono::FixedOffset>,
 }
 
 impl QueryAst {
 	pub fn matches(&self, entry: &LogEntry) -> Result<bool, String> {
-		check_expr(&self.root, entry)
+		let tz = self
+			.tz_offset
+			.unwrap_or_else(|| chrono::FixedOffset::east_opt(0).unwrap());
+		check_expr(&self.root, entry, &tz)
 	}
 }
 

--- a/ts/logs.ts
+++ b/ts/logs.ts
@@ -136,9 +136,10 @@ export const logsSearchPage = (args: LogsSearchPageArgs) => {
 	const startHistogram = () => {
 		histogramContainer.style.display = "block"
 		histogram.clear()
-		const params = new URLSearchParams()
-		if (searchTextarea.value) params.set("query", searchTextarea.value)
-		params.set("bucketSecs", "60")
+                const params = new URLSearchParams()
+                if (searchTextarea.value) params.set("query", searchTextarea.value)
+                params.set("bucketSecs", "60")
+                params.set("tzOffset", new Date().getTimezoneOffset().toString())
 		const url = new URL("/api/v1/logs/histogram", window.location.origin)
 		url.search = params.toString()
 		const es = new EventSource(url)

--- a/ts/main-page.ts
+++ b/ts/main-page.ts
@@ -9,8 +9,9 @@ export const mainPage = (root: HTMLElement) => {
 		streamLogs: (args, onNewLog, onEnd) => {
 			const streamQuery = new URLSearchParams()
 			if (args.query) streamQuery.append("query", args.query)
-			if (args.count) streamQuery.append("count", args.count.toString())
-			if (args.endDate) streamQuery.append("endDate", args.endDate)
+                        if (args.count) streamQuery.append("count", args.count.toString())
+                        if (args.endDate) streamQuery.append("endDate", args.endDate)
+                        streamQuery.append("tzOffset", new Date().getTimezoneOffset().toString())
 			const streamUrl = new URL("/api/logs", window.location.origin)
 			streamUrl.search = streamQuery.toString()
 			const eventSource = new EventSource(streamUrl)


### PR DESCRIPTION
## Summary
- send browser timezone offset with log/histogram requests
- parse `tzOffset` on backend routes
- apply timezone when evaluating timestamp fields
- bundle updated frontend assets

## Testing
- `bun build ./ts/app.ts --outfile=./assets/puppylog.js`
- `bun x tsc --noEmit` *(fails: several TS errors)*
- `cargo fmt --all -- --check`
- `cargo clippy --workspace` *(fails: lock file version 4 requires `-Znext-lockfile-bump`)*
- `cargo test --workspace --frozen --offline` *(fails: lock file version 4 requires `-Znext-lockfile-bump`)*

------
https://chatgpt.com/codex/tasks/task_e_6844534004548326a20fb9bf1d067240