### PR TITLE
Add note about quoting search strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ PuppyLog is a log collection server where clients can submit logs and send queri
 <property> not matches <regex>
 ```
 
+To search for a string that contains a quote character, escape it with a backslash. Example:
+`msg like "\"error\""`
+
+
 **Type Coercion**
 
 ```

--- a/core/src/query_eval.rs
+++ b/core/src/query_eval.rs
@@ -705,6 +705,14 @@ mod tests {
 	}
 
 	#[test]
+	fn message_like_with_quotes() {
+		let mut log = create_test_log_entry();
+		log.msg = "An \"error\" occurred".to_string();
+		let ast = crate::parse_log_query(r#"msg like "\"error\"""#).unwrap();
+		assert!(check_expr(&ast.root, &log, &chrono::FixedOffset::east_opt(0).unwrap()).unwrap());
+	}
+
+	#[test]
 	fn test_prop_like_operator() {
 		let log = create_test_log_entry();
 

--- a/ts/devices.ts
+++ b/ts/devices.ts
@@ -1,5 +1,5 @@
 import { showModal } from "./common"
-import { Button, Container, Header, HList, Label, MultiCheckboxSelect, Select, SelectGroup, TextInput, UiComponent, vlist, VList } from "./ui"
+import { Button, Container, Header, HList, Label, MultiCheckboxSelect, Select, SelectGroup, TextInput, UiComponent, VList } from "./ui"
 import { formatBytes, formatNumber } from "./utility"
 
 const saveDeviceSettings = async (device: DeviceSetting) => {


### PR DESCRIPTION
## Summary
- document how to search for text with quotes
- fix broken import
- test query parsing with escaped quotes

## Testing
- `cargo fmt --all -- --check`
- `cargo test --workspace --frozen --offline`
- `cargo clippy --workspace`
- `bun build ./ts/app.ts --outfile=./assets/puppylog.js`
- `bun x tsc --noEmit` *(fails: implicit any types in pivot.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68447dd3f344832690216931830cd047