### PR TITLE
Add CLI subcommand for segment import

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1691,17 +1691,20 @@ dependencies = [
 name = "puppylogcli"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "chrono",
  "clap",
  "flate2",
  "lazy_static",
  "log",
  "puppylog",
+ "puppylog-server",
  "rand 0.8.5",
  "reqwest",
  "serde",
  "serde_json",
  "tokio",
+ "zstd",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,9 @@ name = "puppylog-server"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+path = "src/lib.rs"
+
 [dependencies]
 tokio = { version = "1", features = ["full"] }
 axum = { version = "0.8", features = ["macros", "ws"] }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -15,3 +15,7 @@ lazy_static = "1"
 puppylog = { path = "../core" }
 log = "0.4"
 serde_json = "1"
+puppylog-server = { path = ".." }
+anyhow = "1"
+zstd = "0.13"
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,4 @@
+pub mod config;
+pub mod db;
+pub mod segment;
+pub mod types;


### PR DESCRIPTION
## Summary
- expose server modules as a small library for reuse
- implement `import` command in `puppylogcli`
- remove temporary clap CLI from the server

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --workspace` *(with warnings)*
- `cargo test --workspace --frozen --offline`
- `bun build ./ts/app.ts --outfile=./assets/puppylog.js`
- `bunx tsc --noEmit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845486b6a2c8326a67f00506d551ac1