### PR TITLE
Add LruCache to device merger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1688,6 +1688,7 @@ dependencies = [
  "hyper",
  "libc",
  "log",
+ "lru",
  "puppylog",
  "rand 0.9.1",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ rusqlite = { version =  "0.33", features = ["bundled", "chrono"] }
 tokio-util = { version = "0.7", features = ["io"] }
 reqwest = { version = "0.12", features = ["json"] }
 libc = "0.2"
+lru = "0.14"
 
 [dev-dependencies]
 tempfile = "3"


### PR DESCRIPTION
## Summary
- limit memory usage in `DeviceMerger` using `lru::LruCache`
- flush devices when the new `PER_DEVICE_MAX` or `MAX_IN_CORE` bounds are hit
- add `lru` crate dependency
- expose `DeviceMerger::with_limits` for testing and add test for eviction

## Testing
- `cargo fmt --all`
- `cargo clippy --workspace`
- `cargo test --workspace --frozen --offline`
- `npm run build`
- `npm run format`
- `npm test` *(fails: ReferenceError: window is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_684e6628358c832682394ed770c65885