### PR TITLE
Implement pagination and search for devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,14 @@ Bulk edit settings for multiple devices identified by their ids.
 
 Returns list of known devices in json format.
 
+#### Query
+
+| Field  | DataType | Description                                 |
+| ------ | -------- | ------------------------------------------- |
+| count  | number   | Devices per page (default 100)              |
+| page   | number   | Page number starting from 0                 |
+| search | string   | Filter devices by id containing this string |
+
 ### GET /api/v1/validate_query
 
 Validate a PQL query string. Returns `200` if valid otherwise `400` with error.

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,7 +53,7 @@ use tower_http::cors::AllowMethods;
 use tower_http::cors::Any;
 use tower_http::cors::CorsLayer;
 use tower_http::decompression::RequestDecompressionLayer;
-use types::GetSegmentsQuery;
+use types::{GetDevicesQuery, GetSegmentsQuery};
 
 mod background;
 mod cache;
@@ -332,8 +332,14 @@ async fn update_device_settings(
 	"ok"
 }
 
-async fn get_devices(State(ctx): State<Arc<Context>>) -> Json<Value> {
-	let devices = ctx.db.get_devices().await.unwrap();
+async fn get_devices(
+	State(ctx): State<Arc<Context>>,
+	Query(mut params): Query<GetDevicesQuery>,
+) -> Json<Value> {
+	if params.count.is_none() {
+		params.count = Some(100);
+	}
+	let devices = ctx.db.get_devices(&params).await.unwrap();
 	Json(serde_json::to_value(&devices).unwrap())
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -17,3 +17,10 @@ pub struct GetSegmentsQuery {
 	pub count: Option<usize>,
 	pub sort: Option<SortDir>,
 }
+
+#[derive(Deserialize, Debug, Default)]
+pub struct GetDevicesQuery {
+	pub search: Option<String>,
+	pub page: Option<usize>,
+	pub count: Option<usize>,
+}

--- a/ts/logs.ts
+++ b/ts/logs.ts
@@ -217,7 +217,8 @@ export const logsSearchPage = (args: LogsSearchPageArgs) => {
 			document.querySelectorAll(".msg-summary").forEach((el, key) => {
 				el.addEventListener("click", () => {
 					const entry = logEntries[key]
-					const isTruncated = entry.msg.length > MESSAGE_TRUNCATE_LENGTH
+					const isTruncated =
+						entry.msg.length > MESSAGE_TRUNCATE_LENGTH
 					if (!isTruncated) {
 						return
 					}

--- a/ts/ui.ts
+++ b/ts/ui.ts
@@ -150,6 +150,10 @@ export class TextInput extends UiComponent<HTMLDivElement> {
 	public get value(): string {
 		return this.input.value
 	}
+
+	public set onChange(callback: (value: string) => void) {
+		this.input.oninput = () => callback(this.input.value)
+	}
 }
 
 export class MultiCheckboxSelect extends UiComponent<HTMLDivElement> {


### PR DESCRIPTION
## Summary
- add new API query parameters for fetching devices
- support pagination and search on the devices page
- expose new TextInput change handler
- document device query params

## Testing
- `cargo clippy --workspace`
- `cargo test --workspace --frozen --offline`
- `npm run format`
- `npm run build`
- `npm test` *(fails: ReferenceError: window is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6865f8869e308326b6c3e422e33c6fb1