### PR TITLE
Add device details page

### DIFF
--- a/ts/app.ts
+++ b/ts/app.ts
@@ -4,6 +4,7 @@ import { mainPage } from "./main-page"
 import { PivotPage } from "./pivot"
 import { routes } from "./router"
 import { segmentPage, segmentsPage } from "./segment-page"
+import { devicePage } from "./device-page"
 import { settingsPage } from "./settings"
 import { Container } from "./ui"
 import { queriesPage } from "./queries"
@@ -22,6 +23,7 @@ window.onload = () => {
 		"/queries": () => queriesPage(body),
 		"/segment/:segmentId": (params: any) =>
 			segmentPage(body, params.segmentId),
+		"/device/:deviceId": (params: any) => devicePage(body, params.deviceId),
 		"/pivot": () => PivotPage(body),
 		"/*": () => mainPage(body),
 	})

--- a/ts/device-page.ts
+++ b/ts/device-page.ts
@@ -1,0 +1,79 @@
+import { logsSearchPage, FetchMoreArgs, LogEntry } from "./logs"
+import { Navbar } from "./navbar"
+import { Container } from "./ui"
+import { formatBytes, formatNumber } from "./utility"
+import type { DeviceSetting } from "./devices"
+
+export const devicePage = async (root: HTMLElement, deviceId: string) => {
+	root.innerHTML = ""
+	const container = new Container(root)
+	const navbar = new Navbar()
+	container.add(navbar)
+
+	const res = await fetch("/api/v1/devices")
+	const devices = (await res.json()) as DeviceSetting[]
+	const device = devices.find((d) => d.id === deviceId)
+	if (!device) {
+		container.root.textContent = "Device not found"
+		return
+	}
+
+	const details = document.createElement("div")
+	details.className = "device-details"
+	const addDetail = (k: string, v: string) => {
+		const div = document.createElement("div")
+		div.innerHTML = `<strong>${k}:</strong> ${v}`
+		details.appendChild(div)
+	}
+	addDetail("ID", device.id)
+	addDetail("Created", new Date(device.createdAt).toLocaleString())
+	addDetail("Last upload", new Date(device.lastUploadAt).toLocaleString())
+	addDetail("Send logs", device.sendLogs ? "Yes" : "No")
+	addDetail("Filter level", device.filterLevel)
+	addDetail("Send interval", device.sendInterval.toString())
+	addDetail("Logs count", formatNumber(device.logsCount))
+	addDetail("Logs size", formatBytes(device.logsSize))
+	for (const prop of device.props) addDetail(prop.key, prop.value)
+	container.root.appendChild(details)
+
+	const logsContainer = document.createElement("div")
+	container.root.appendChild(logsContainer)
+
+	const buildQuery = (q?: string) =>
+		q && q.trim()
+			? `deviceId=\"${deviceId}\" AND (${q})`
+			: `deviceId=\"${deviceId}\"`
+
+	logsSearchPage({
+		root: logsContainer,
+		streamLogs: (
+			args: FetchMoreArgs,
+			onNew: (l: LogEntry) => void,
+			onEnd: () => void,
+		) => {
+			const fullQuery = buildQuery(args.query)
+			const params = new URLSearchParams()
+			if (fullQuery) params.append("query", fullQuery)
+			if (args.count) params.append("count", args.count.toString())
+			if (args.endDate) params.append("endDate", args.endDate)
+			params.append("tzOffset", new Date().getTimezoneOffset().toString())
+			const url = new URL("/api/logs", window.location.origin)
+			url.search = params.toString()
+			const es = new EventSource(url)
+			es.onmessage = (ev) => onNew(JSON.parse(ev.data))
+			es.onerror = () => {
+				es.close()
+				onEnd()
+			}
+			return () => es.close()
+		},
+		validateQuery: async (query: string) => {
+			const q = buildQuery(query)
+			const res = await fetch(
+				`/api/v1/validate_query?query=${encodeURIComponent(q)}`,
+			)
+			if (res.status === 200) return null
+			return res.text()
+		},
+	})
+}

--- a/ts/devices.ts
+++ b/ts/devices.ts
@@ -42,7 +42,7 @@ type Prop = {
 	value: string
 }
 
-type DeviceSetting = {
+export type DeviceSetting = {
 	id: string
 	sendLogs: boolean
 	filterLevel: string
@@ -68,7 +68,7 @@ export class DeviceRow extends UiComponent<HTMLDivElement> {
 		// ID cell
 		const idCell = document.createElement("div")
 		idCell.className = "table-cell"
-		idCell.innerHTML = `<strong>ID:</strong> ${device.id}`
+		idCell.innerHTML = `<strong>ID:</strong> <a href="/device/${device.id}">${device.id}</a>`
 		this.root.appendChild(idCell)
 
 		// Created at cell

--- a/ts/router.test.ts
+++ b/ts/router.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test"
 
-test("asdf", () => {
-	window.location.pathname
+test("dummy", () => {
+        expect(true).toBe(true)
 })


### PR DESCRIPTION
## Summary
- expose `DeviceSetting` type for reuse
- add device details page with metadata and log viewer
- link to device page from devices table
- register device route in router
- update placeholder router test

## Testing
- `npm run format`
- `npm run build`
- `npm test`
- `cargo clippy --workspace`
- `cargo test --workspace --frozen --offline`


------
https://chatgpt.com/codex/tasks/task_e_686b6444b6d883268c3dc10d380c018f