### PR TITLE
Add global navbar across pages

### DIFF
--- a/ts/app.ts
+++ b/ts/app.ts
@@ -6,6 +6,7 @@ import { routes } from "./router"
 import { segmentPage, segmentsPage } from "./segment-page"
 import { settingsPage } from "./settings"
 import { Container } from "./ui"
+import { Navbar } from "./navbar"
 import { queriesPage } from "./queries"
 
 window.onload = () => {
@@ -14,15 +15,36 @@ window.onload = () => {
 		throw new Error("No body element found")
 	}
 	const container = new Container(body)
+	const navbar = new Navbar()
+	container.add(navbar)
+	const pageRoot = document.createElement("div")
+	const pageContainer = new Container(pageRoot)
+	container.add(pageContainer)
+
+	const renderElem =
+		(handler: (root: HTMLElement, nav: Navbar) => any) => () => {
+			pageRoot.innerHTML = ""
+			navbar.setRight()
+			handler(pageRoot, navbar)
+		}
+	const renderContainer =
+		(handler: (root: Container, nav: Navbar) => any) => () => {
+			pageRoot.innerHTML = ""
+			navbar.setRight()
+			handler(pageContainer, navbar)
+		}
 	routes({
-		"/tests/logs": () => logtableTest(body),
-		"/settings": () => settingsPage(container),
-		"/devices": () => devicesPage(body),
-		"/segments": () => segmentsPage(container),
-		"/queries": () => queriesPage(body),
-		"/segment/:segmentId": (params: any) =>
-			segmentPage(body, params.segmentId),
-		"/pivot": () => PivotPage(body),
-		"/*": () => mainPage(body),
+		"/tests/logs": renderElem(logtableTest),
+		"/settings": renderContainer(settingsPage),
+		"/devices": renderElem(devicesPage),
+		"/segments": renderContainer(segmentsPage),
+		"/queries": renderElem(queriesPage),
+		"/segment/:segmentId": (params: any) => {
+			pageRoot.innerHTML = ""
+			navbar.setRight()
+			segmentPage(pageRoot, params.segmentId, navbar)
+		},
+		"/pivot": renderElem(PivotPage),
+		"/*": renderElem(mainPage),
 	})
 }

--- a/ts/devices.ts
+++ b/ts/devices.ts
@@ -212,10 +212,10 @@ class DevicesList implements UiComponent<HTMLDivElement> {
 	}
 }
 
-export const devicesPage = async (root: HTMLElement) => {
+export const devicesPage = async (root: HTMLElement, navbar?: Navbar) => {
 	const page = new Container(root)
-	const navbar = new Navbar()
-	page.add(navbar)
+	const nav = navbar ?? new Navbar()
+	page.add(nav)
 
 	// Fetch and compute metadata
 	const res = await fetch("/api/v1/devices")
@@ -253,7 +253,7 @@ export const devicesPage = async (root: HTMLElement) => {
 		buttonText: "Metadata",
 		content: metadataTable,
 	})
-	navbar.setRight([metadataCollapsible])
+	nav.setRight([metadataCollapsible])
 
 	const sendLogsSearchOption = new SelectGroup({
 		label: "Sending logs",
@@ -294,7 +294,7 @@ export const devicesPage = async (root: HTMLElement) => {
 	searchOptions.add(propsFiltters)
 	searchOptions.root.appendChild(bulkEditButton)
 	const devicesList = new DevicesList()
-	page.add(navbar, searchOptions, devicesList)
+	page.add(searchOptions, devicesList)
 
 	const renderList = (devices: DeviceSetting[]) => {
 		devicesList.clear()

--- a/ts/logs.ts
+++ b/ts/logs.ts
@@ -37,6 +37,7 @@ interface LogsSearchPageArgs {
 		onNewLog: (log: LogEntry) => void,
 		onEnd: () => void,
 	) => () => void
+	navbar?: Navbar
 }
 
 const MAX_LOG_ENTRIES = 10_000
@@ -78,8 +79,8 @@ export const logsSearchPage = (args: LogsSearchPageArgs) => {
 	let moreRows = true
 	args.root.innerHTML = ``
 
-	const navbar = new Navbar()
-	args.root.appendChild(navbar.root)
+	const navbar = args.navbar ?? new Navbar()
+	if (!args.navbar) args.root.appendChild(navbar.root)
 
 	const logsOptions = document.createElement("div")
 	logsOptions.className = "page-header"

--- a/ts/logtable-test.ts
+++ b/ts/logtable-test.ts
@@ -1,4 +1,5 @@
 import { LogEntry, logsSearchPage } from "./logs"
+import { Navbar } from "./navbar"
 
 function logline(length: number, linebreaks: number): string {
 	let line = ""
@@ -106,9 +107,13 @@ const createRandomXml = (
 	return nodeToXml(root)
 }
 
-export const logtableTest = (root: HTMLElement): HTMLElement => {
+export const logtableTest = (
+	root: HTMLElement,
+	navbar?: Navbar,
+): HTMLElement => {
 	logsSearchPage({
 		root,
+		navbar,
 		streamLogs: (args, onNewLog, onEnd) => {
 			onNewLog({
 				id: `${Date.now()}-text`,

--- a/ts/main-page.ts
+++ b/ts/main-page.ts
@@ -1,11 +1,13 @@
 import { logsSearchPage } from "./logs"
+import { Navbar } from "./navbar"
 import { getQueryParam, removeQueryParam, setQueryParam } from "./utility"
 
-export const mainPage = (root: HTMLElement) => {
+export const mainPage = (root: HTMLElement, navbar?: Navbar) => {
 	let query: string | undefined = getQueryParam("query") || ""
 	let isStreaming = getQueryParam("stream") === "true"
 	logsSearchPage({
 		root,
+		navbar,
 		streamLogs: (args, onNewLog, onEnd) => {
 			const streamQuery = new URLSearchParams()
 			if (args.query) streamQuery.append("query", args.query)

--- a/ts/segment-page.ts
+++ b/ts/segment-page.ts
@@ -35,7 +35,7 @@ const fetchSegments = async (end: Date) => {
 	return res
 }
 
-export const segmentsPage = async (root: Container) => {
+export const segmentsPage = async (root: Container, navbar?: Navbar) => {
 	const segementsMetadata = (await fetch("/api/segment/metadata").then(
 		(res) => res.json(),
 	)) as SegementsMetadata
@@ -90,8 +90,12 @@ export const segmentsPage = async (root: Container) => {
 		buttonText: "Metadata",
 		content: metadata,
 	})
-	const navbar = new Navbar({ right: [metadataCollapsible] })
-	root.add(navbar)
+	const nav = navbar ?? new Navbar({ right: [metadataCollapsible] })
+	if (navbar) {
+		nav.setRight([metadataCollapsible])
+	} else {
+		root.add(nav)
+	}
 
 	const segmentList = new WrapList()
 	const infiniteScroll = new InfiniteScroll({
@@ -141,7 +145,11 @@ export const segmentsPage = async (root: Container) => {
 	}
 }
 
-export const segmentPage = async (root: HTMLElement, segmentId: number) => {
+export const segmentPage = async (
+	root: HTMLElement,
+	segmentId: number,
+	navbar?: Navbar,
+) => {
 	const segment = (await fetch(`/api/v1/segment/${segmentId}`).then((res) =>
 		res.json(),
 	)) as Segment
@@ -154,9 +162,9 @@ export const segmentPage = async (root: HTMLElement, segmentId: number) => {
 	const totalLogsCount = segment.logsCount
 	const compressRatio = (totalCompressedSize / totalOriginalSize) * 100
 	root.innerHTML = `
-		<div class="page-header">
-			<h1 style="flex-grow: 1">Segment ${segmentId}</h1>
-			<div class="summary">
+                <div class="page-header">
+                        <h1 style="flex-grow: 1">Segment ${segmentId}</h1>
+                        <div class="summary">
 				<div><strong>First timestamp:</strong> ${formatTimestamp(segment.firstTimestamp)}</div>
 				<div><strong>Last timestamp:</strong> ${formatTimestamp(segment.lastTimestamp)}</div>
 				<div><strong>Total original size:</strong> ${formatBytes(totalOriginalSize)}</div>
@@ -176,6 +184,7 @@ export const segmentPage = async (root: HTMLElement, segmentId: number) => {
 			`,
 				)
 				.join("")}
-		</div>
-	`
+                </div>
+        `
+	if (navbar) root.prepend(navbar.root)
 }


### PR DESCRIPTION
## Summary
- create shared `Navbar` in `app.ts`
- inject navbar into page helpers so it can be customized
- adjust pages to accept optional navbar
- update compiled javascript

## Testing
- `npm run format`
- `npm run build`
- `npm test` *(fails: ReferenceError: window is not defined)*
- `cargo fmt`
- `cargo clippy --workspace`
- `cargo test --workspace --frozen --offline`

------
https://chatgpt.com/codex/tasks/task_e_686c9255f46c83268c1e7907d09902bb