### PR TITLE
Persist log buckets on the server

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,80 @@ Each event contains a JSON object:
 }
 ```
 
+### Bucket API
+
+Buckets store copies of log lines that matched a saved query. Each bucket keeps at most 200 log entries, deduplicated by the ori
+ginal log identifier.
+
+#### Bucket object
+
+```json
+{
+	"id": 1,
+	"name": "Errors",
+	"query": "level:error",
+	"createdAt": "2025-03-01T12:00:00Z",
+	"updatedAt": "2025-03-01T12:10:00Z",
+	"logs": [
+		{
+			"id": "abc123",
+			"timestamp": "2025-03-01T12:09:45Z",
+			"level": "error",
+			"msg": "Something exploded",
+			"props": [{ "key": "device", "value": "alpha" }]
+		}
+	]
+}
+```
+
+### GET /api/v1/buckets
+
+Returns an array of bucket objects sorted by `updatedAt` (most recent first).
+
+### POST /api/v1/buckets
+
+Creates or updates a bucket. When an `id` is supplied the existing bucket is updated; otherwise a bucket is created (or the name
+is reused if it already exists).
+
+```json
+{
+	"id": 1,
+	"name": "Errors",
+	"query": "level:error"
+}
+```
+
+Returns the updated bucket object.
+
+### POST /api/v1/buckets/{bucketId}/logs
+
+Appends new log entries to the bucket. Existing entries with the same `id` are ignored, and the bucket is truncated to 200 logs.
+
+```json
+{
+	"logs": [
+		{
+			"id": "abc123",
+			"timestamp": "2025-03-01T12:09:45Z",
+			"level": "error",
+			"msg": "Something exploded",
+			"props": [{ "key": "device", "value": "alpha" }]
+		}
+	]
+}
+```
+
+Returns the updated bucket, or HTTP 404 if the bucket does not exist.
+
+### POST /api/v1/buckets/{bucketId}/clear
+
+Removes all stored log entries from the bucket and returns the emptied bucket object. Responds with HTTP 404 if the bucket does
+not exist.
+
+### DELETE /api/v1/buckets/{bucketId}
+
+Deletes the bucket and all stored copies. Returns HTTP 204 on success or HTTP 404 if the bucket is missing.
+
 ### POST /api/v1/device/settings
 
 Apply settings to many devices at once. Devices are matched based on metadata uploaded by devices.

--- a/src/controllers.rs
+++ b/src/controllers.rs
@@ -22,7 +22,10 @@ use tokio_util::io::ReaderStream;
 
 use crate::config::{log_path, upload_path};
 use crate::context::{Context, LogStreamItem, SearchProgress, SegmentProgress};
-use crate::db::{MetaProp, UpdateDeviceSettings};
+use crate::db::{
+	BucketProp, LogBucket, MetaProp, NewBucketLogEntry, UpdateDeviceSettings, UpsertBucketArgs,
+	BUCKET_LOG_LIMIT,
+};
 use crate::types::GetSegmentsQuery;
 
 #[derive(Deserialize, Debug)]
@@ -41,6 +44,74 @@ pub(crate) struct GetHistogramQuery {
 	pub bucket_secs: Option<u64>,
 	pub end_date: Option<DateTime<Utc>>,
 	pub tz_offset: Option<i32>,
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct UpsertBucketRequest {
+	pub id: Option<i32>,
+	pub name: String,
+	pub query: Option<String>,
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+struct BucketPropPayload {
+	key: String,
+	value: String,
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+struct BucketLogEntryPayload {
+	id: String,
+	timestamp: String,
+	level: String,
+	msg: String,
+	#[serde(default)]
+	props: Vec<BucketPropPayload>,
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct AppendBucketLogsRequest {
+	#[serde(default)]
+	logs: Vec<BucketLogEntryPayload>,
+}
+
+fn normalize_bucket_prop(prop: BucketPropPayload) -> Option<BucketProp> {
+	let key = prop.key.trim();
+	if key.is_empty() {
+		return None;
+	}
+	Some(BucketProp {
+		key: key.to_string(),
+		value: prop.value.trim().to_string(),
+	})
+}
+
+fn normalize_bucket_log(entry: BucketLogEntryPayload) -> Option<NewBucketLogEntry> {
+	let id = entry.id.trim();
+	let timestamp = entry.timestamp.trim();
+	if id.is_empty() || timestamp.is_empty() {
+		return None;
+	}
+	let level = match entry.level.as_str() {
+		"trace" | "debug" | "info" | "warn" | "error" | "fatal" => entry.level,
+		_ => return None,
+	};
+	let props = entry
+		.props
+		.into_iter()
+		.filter_map(normalize_bucket_prop)
+		.collect();
+	Some(NewBucketLogEntry {
+		id: id.to_string(),
+		timestamp: timestamp.to_string(),
+		level,
+		msg: entry.msg,
+		props,
+	})
 }
 
 #[derive(Serialize)]
@@ -109,13 +180,83 @@ pub async fn get_segment_metadata(State(ctx): State<Arc<Context>>) -> Json<Value
 	let avg_logs_per_segment = meta.logs_count as f64 / meta.segment_count as f64;
 	let avg_segment_size = meta.original_size as f64 / meta.segment_count as f64;
 	Json(json!({
-		"segmentCount": meta.segment_count,
-		"originalSize": meta.original_size,
-		"compressedSize": meta.compressed_size,
-		"logsCount": meta.logs_count,
-		"averageLogsPerSegment": avg_logs_per_segment,
-		"averageSegmentSize": avg_segment_size
+			"segmentCount": meta.segment_count,
+			"originalSize": meta.original_size,
+			"compressedSize": meta.compressed_size,
+			"logsCount": meta.logs_count,
+			"averageLogsPerSegment": avg_logs_per_segment,
+			"averageSegmentSize": avg_segment_size
 	}))
+}
+
+pub async fn list_buckets(
+	State(ctx): State<Arc<Context>>,
+) -> Result<Json<Vec<LogBucket>>, StatusCode> {
+	ctx.db
+		.list_buckets()
+		.await
+		.map(Json)
+		.map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)
+}
+
+pub async fn upsert_bucket(
+	State(ctx): State<Arc<Context>>,
+	Json(payload): Json<UpsertBucketRequest>,
+) -> Result<Json<LogBucket>, StatusCode> {
+	let name = payload.name.trim();
+	if name.is_empty() {
+		return Err(StatusCode::BAD_REQUEST);
+	}
+	let query = payload.query.unwrap_or_default();
+	ctx.db
+		.upsert_bucket(UpsertBucketArgs {
+			id: payload.id,
+			name: name.to_string(),
+			query,
+		})
+		.await
+		.map(Json)
+		.map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)
+}
+
+pub async fn append_bucket_logs(
+	State(ctx): State<Arc<Context>>,
+	Path(bucket_id): Path<i32>,
+	Json(payload): Json<AppendBucketLogsRequest>,
+) -> Result<Json<LogBucket>, StatusCode> {
+	let logs: Vec<NewBucketLogEntry> = payload
+		.logs
+		.into_iter()
+		.filter_map(normalize_bucket_log)
+		.take(BUCKET_LOG_LIMIT)
+		.collect();
+	match ctx.db.append_bucket_logs(bucket_id, &logs).await {
+		Ok(Some(bucket)) => Ok(Json(bucket)),
+		Ok(None) => Err(StatusCode::NOT_FOUND),
+		Err(_) => Err(StatusCode::INTERNAL_SERVER_ERROR),
+	}
+}
+
+pub async fn clear_bucket_logs(
+	State(ctx): State<Arc<Context>>,
+	Path(bucket_id): Path<i32>,
+) -> Result<Json<LogBucket>, StatusCode> {
+	match ctx.db.clear_bucket_logs(bucket_id).await {
+		Ok(Some(bucket)) => Ok(Json(bucket)),
+		Ok(None) => Err(StatusCode::NOT_FOUND),
+		Err(_) => Err(StatusCode::INTERNAL_SERVER_ERROR),
+	}
+}
+
+pub async fn delete_bucket(
+	State(ctx): State<Arc<Context>>,
+	Path(bucket_id): Path<i32>,
+) -> StatusCode {
+	match ctx.db.delete_bucket(bucket_id).await {
+		Ok(true) => StatusCode::NO_CONTENT,
+		Ok(false) => StatusCode::NOT_FOUND,
+		Err(_) => StatusCode::INTERNAL_SERVER_ERROR,
+	}
 }
 
 pub async fn get_segment(
@@ -857,8 +998,9 @@ mod tests {
 	use super::*;
 	use axum::body::{to_bytes, Body};
 	use axum::http::{Request, StatusCode};
-	use axum::routing::get;
+	use axum::routing::{delete, get, post};
 	use axum::Router;
+	use serde_json::{json, Value};
 	use tempfile::TempDir;
 	use tower::ServiceExt;
 
@@ -1003,6 +1145,139 @@ mod tests {
 		let body = to_bytes(res.into_body(), usize::MAX).await.unwrap();
 		let logs: Vec<serde_json::Value> = serde_json::from_slice(&body).unwrap();
 		assert_eq!(logs.len(), 2);
+	}
+
+	#[tokio::test]
+	async fn bucket_endpoints_roundtrip() {
+		let dir = TempDir::new().unwrap();
+		let log_dir = dir.path().join("logs");
+		std::fs::create_dir_all(&log_dir).unwrap();
+		std::env::set_var("LOG_PATH", &log_dir);
+		std::env::set_var("DB_PATH", dir.path().join("db.sqlite"));
+		std::env::set_var("SETTINGS_PATH", dir.path().join("settings.json"));
+		std::fs::write(
+			dir.path().join("settings.json"),
+			"{\"collection_query\":\"\"}",
+		)
+		.unwrap();
+
+		let ctx = Arc::new(Context::new(log_dir).await);
+
+		let app = Router::new()
+			.route("/api/v1/buckets", get(list_buckets).post(upsert_bucket))
+			.route("/api/v1/buckets/{bucketId}/logs", post(append_bucket_logs))
+			.route("/api/v1/buckets/{bucketId}/clear", post(clear_bucket_logs))
+			.route("/api/v1/buckets/{bucketId}", delete(delete_bucket))
+			.with_state(ctx);
+
+		let create_res = app
+			.clone()
+			.oneshot(
+				Request::builder()
+					.method("POST")
+					.uri("/api/v1/buckets")
+					.header("content-type", "application/json")
+					.body(Body::from(
+						json!({
+								"name": "Errors",
+								"query": "level:error"
+						})
+						.to_string(),
+					))
+					.unwrap(),
+			)
+			.await
+			.unwrap();
+		assert_eq!(create_res.status(), StatusCode::OK);
+		let body = to_bytes(create_res.into_body(), usize::MAX).await.unwrap();
+		let created: Value = serde_json::from_slice(&body).unwrap();
+		let bucket_id = created["id"].as_i64().unwrap() as i32;
+
+		let list_res = app
+			.clone()
+			.oneshot(
+				Request::builder()
+					.uri("/api/v1/buckets")
+					.body(Body::empty())
+					.unwrap(),
+			)
+			.await
+			.unwrap();
+		assert_eq!(list_res.status(), StatusCode::OK);
+		let list_body = to_bytes(list_res.into_body(), usize::MAX).await.unwrap();
+		let listed: Value = serde_json::from_slice(&list_body).unwrap();
+		assert_eq!(listed.as_array().unwrap().len(), 1);
+
+		let append_payload = json!({
+				"logs": [
+						{
+								"id": "log-1",
+								"timestamp": Utc::now().to_rfc3339(),
+								"level": "info",
+								"msg": "hello",
+								"props": [{"key": "device", "value": "alpha"}]
+						}
+				]
+		});
+		let append_res = app
+			.clone()
+			.oneshot(
+				Request::builder()
+					.method("POST")
+					.uri(format!("/api/v1/buckets/{bucket_id}/logs"))
+					.header("content-type", "application/json")
+					.body(Body::from(append_payload.to_string()))
+					.unwrap(),
+			)
+			.await
+			.unwrap();
+		assert_eq!(append_res.status(), StatusCode::OK);
+		let append_body = to_bytes(append_res.into_body(), usize::MAX).await.unwrap();
+		let appended: Value = serde_json::from_slice(&append_body).unwrap();
+		assert_eq!(appended["logs"].as_array().unwrap().len(), 1);
+
+		let clear_res = app
+			.clone()
+			.oneshot(
+				Request::builder()
+					.method("POST")
+					.uri(format!("/api/v1/buckets/{bucket_id}/clear"))
+					.body(Body::empty())
+					.unwrap(),
+			)
+			.await
+			.unwrap();
+		assert_eq!(clear_res.status(), StatusCode::OK);
+		let cleared: Value =
+			serde_json::from_slice(&to_bytes(clear_res.into_body(), usize::MAX).await.unwrap())
+				.unwrap();
+		assert_eq!(cleared["logs"].as_array().unwrap().len(), 0);
+
+		let delete_res = app
+			.clone()
+			.oneshot(
+				Request::builder()
+					.method("DELETE")
+					.uri(format!("/api/v1/buckets/{bucket_id}"))
+					.body(Body::empty())
+					.unwrap(),
+			)
+			.await
+			.unwrap();
+		assert_eq!(delete_res.status(), StatusCode::NO_CONTENT);
+
+		let final_list = app
+			.oneshot(
+				Request::builder()
+					.uri("/api/v1/buckets")
+					.body(Body::empty())
+					.unwrap(),
+			)
+			.await
+			.unwrap();
+		let final_body = to_bytes(final_list.into_body(), usize::MAX).await.unwrap();
+		let after: Value = serde_json::from_slice(&final_body).unwrap();
+		assert!(after.as_array().unwrap().is_empty());
 	}
 
 	#[tokio::test]

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,11 +1,10 @@
 use std::collections::HashMap;
 use std::fs::create_dir_all;
 
-use anyhow::Context;
-use anyhow::Result;
+use anyhow::{Context, Result};
 use chrono::{DateTime, NaiveDateTime, Utc};
 use diesel::connection::SimpleConnection;
-use diesel::dsl::exists;
+use diesel::dsl::{exists, now};
 use diesel::expression::BoxableExpression;
 use diesel::prelude::*;
 use diesel::r2d2::{ConnectionManager, CustomizeConnection, Pool, PooledConnection};
@@ -16,7 +15,9 @@ use puppylog::{LogLevel, Prop};
 use serde::{Deserialize, Serialize};
 
 use crate::config::db_path;
-use crate::schema::{device_props, devices, log_segments, migrations, segment_props};
+use crate::schema::{
+	bucket_logs, device_props, devices, log_buckets, log_segments, migrations, segment_props,
+};
 use crate::segment::SegmentMeta;
 use crate::types::{GetSegmentsQuery, SortDir};
 
@@ -87,6 +88,33 @@ const MIGRATIONS: &[Migration] = &[
                         CREATE INDEX IF NOT EXISTS log_segments_device_id_idx ON log_segments(device_id);
                 "#,
 	},
+	Migration {
+		id: 20250624,
+		name: "log_buckets",
+		sql: r#"
+                        CREATE TABLE log_buckets (
+                                        id INTEGER PRIMARY KEY AUTOINCREMENT,
+                                        name TEXT NOT NULL UNIQUE,
+                                        query TEXT NOT NULL DEFAULT '',
+                                        created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                                        updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+                        );
+                        CREATE TABLE bucket_logs (
+                                        id INTEGER PRIMARY KEY AUTOINCREMENT,
+                                        bucket_id INTEGER NOT NULL,
+                                        log_id TEXT NOT NULL,
+                                        timestamp TEXT NOT NULL,
+                                        level TEXT NOT NULL,
+                                        msg TEXT NOT NULL,
+                                        props TEXT NOT NULL,
+                                        created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                                        UNIQUE(bucket_id, log_id),
+                                        FOREIGN KEY(bucket_id) REFERENCES log_buckets(id) ON DELETE CASCADE
+                        );
+                        CREATE INDEX IF NOT EXISTS bucket_logs_bucket_id_created_at_idx
+                                ON bucket_logs(bucket_id, created_at DESC);
+                "#,
+	},
 ];
 
 #[derive(Debug, Default)]
@@ -97,8 +125,10 @@ impl CustomizeConnection<SqliteConnection, diesel::r2d2::Error> for SqlitePragma
 		&self,
 		conn: &mut SqliteConnection,
 	) -> std::result::Result<(), diesel::r2d2::Error> {
-		conn.batch_execute("PRAGMA journal_mode=WAL; PRAGMA busy_timeout = 5000;")
-			.map_err(diesel::r2d2::Error::QueryError)
+		conn.batch_execute(
+			"PRAGMA journal_mode=WAL; PRAGMA busy_timeout = 5000; PRAGMA foreign_keys = ON;",
+		)
+		.map_err(diesel::r2d2::Error::QueryError)
 	}
 }
 
@@ -196,6 +226,94 @@ struct NewSegmentRecord {
 	logs_count: i64,
 }
 
+#[derive(Queryable, Debug)]
+#[diesel(table_name = log_buckets)]
+struct LogBucketRow {
+	id: i32,
+	name: String,
+	query: String,
+	created_at: NaiveDateTime,
+	updated_at: NaiveDateTime,
+}
+
+#[derive(Queryable, Debug)]
+#[diesel(table_name = bucket_logs)]
+struct BucketLogRow {
+	id: i32,
+	bucket_id: i32,
+	log_id: String,
+	timestamp: String,
+	level: String,
+	msg: String,
+	props: String,
+	created_at: NaiveDateTime,
+}
+
+#[derive(Insertable)]
+#[diesel(table_name = log_buckets)]
+struct NewLogBucketRecord {
+	name: String,
+	query: String,
+}
+
+#[derive(Insertable)]
+#[diesel(table_name = bucket_logs)]
+struct NewBucketLogRecord {
+	bucket_id: i32,
+	log_id: String,
+	timestamp: String,
+	level: String,
+	msg: String,
+	props: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BucketProp {
+	pub key: String,
+	pub value: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BucketLogEntry {
+	pub id: String,
+	pub timestamp: String,
+	pub level: String,
+	pub msg: String,
+	pub props: Vec<BucketProp>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LogBucket {
+	pub id: i32,
+	pub name: String,
+	pub query: String,
+	pub created_at: String,
+	pub updated_at: String,
+	pub logs: Vec<BucketLogEntry>,
+}
+
+#[derive(Debug, Clone)]
+pub struct UpsertBucketArgs {
+	pub id: Option<i32>,
+	pub name: String,
+	pub query: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct NewBucketLogEntry {
+	pub id: String,
+	pub timestamp: String,
+	pub level: String,
+	pub msg: String,
+	pub props: Vec<BucketProp>,
+}
+
+const MAX_BUCKET_ENTRIES: usize = 200;
+pub const BUCKET_LOG_LIMIT: usize = MAX_BUCKET_ENTRIES;
+
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Device {
@@ -284,6 +402,234 @@ impl DB {
 		self.read_pool
 			.get()
 			.context("failed to get sqlite read connection from pool")
+	}
+
+	fn decode_bucket_log(row: &BucketLogRow) -> Option<BucketLogEntry> {
+		if row.log_id.is_empty() || row.timestamp.is_empty() {
+			return None;
+		}
+		let props: Vec<BucketProp> = serde_json::from_str(&row.props).unwrap_or_default();
+		Some(BucketLogEntry {
+			id: row.log_id.clone(),
+			timestamp: row.timestamp.clone(),
+			level: row.level.clone(),
+			msg: row.msg.clone(),
+			props,
+		})
+	}
+
+	fn assemble_bucket(row: LogBucketRow, logs: Vec<BucketLogEntry>) -> LogBucket {
+		LogBucket {
+			id: row.id,
+			name: row.name,
+			query: row.query,
+			created_at: naive_to_utc(row.created_at).to_rfc3339(),
+			updated_at: naive_to_utc(row.updated_at).to_rfc3339(),
+			logs,
+		}
+	}
+
+	pub async fn list_buckets(&self) -> Result<Vec<LogBucket>> {
+		let mut conn = self.read_conn()?;
+		let rows: Vec<LogBucketRow> = log_buckets::table
+			.order(log_buckets::updated_at.desc())
+			.load(&mut conn)?;
+		if rows.is_empty() {
+			return Ok(Vec::new());
+		}
+		let ids: Vec<i32> = rows.iter().map(|row| row.id).collect();
+		let log_rows: Vec<BucketLogRow> = bucket_logs::table
+			.filter(bucket_logs::bucket_id.eq_any(&ids))
+			.order((bucket_logs::bucket_id.asc(), bucket_logs::created_at.desc()))
+			.load(&mut conn)?;
+		let mut grouped: HashMap<i32, Vec<BucketLogEntry>> = HashMap::new();
+		for row in log_rows {
+			if let Some(entry) = Self::decode_bucket_log(&row) {
+				grouped.entry(row.bucket_id).or_default().push(entry);
+			}
+		}
+		let mut buckets = Vec::with_capacity(rows.len());
+		for row in rows {
+			let logs = grouped.remove(&row.id).unwrap_or_default();
+			buckets.push(Self::assemble_bucket(row, logs));
+		}
+		Ok(buckets)
+	}
+
+	pub async fn get_bucket(&self, bucket_id: i32) -> Result<Option<LogBucket>> {
+		let mut conn = self.read_conn()?;
+		let bucket = log_buckets::table
+			.filter(log_buckets::id.eq(bucket_id))
+			.first::<LogBucketRow>(&mut conn)
+			.optional()?;
+		let Some(row) = bucket else {
+			return Ok(None);
+		};
+		let log_rows: Vec<BucketLogRow> = bucket_logs::table
+			.filter(bucket_logs::bucket_id.eq(bucket_id))
+			.order(bucket_logs::created_at.desc())
+			.load(&mut conn)?;
+		let mut logs = Vec::with_capacity(log_rows.len());
+		for log_row in log_rows.iter() {
+			if let Some(entry) = Self::decode_bucket_log(log_row) {
+				logs.push(entry);
+			}
+		}
+		Ok(Some(Self::assemble_bucket(row, logs)))
+	}
+
+	pub async fn upsert_bucket(&self, args: UpsertBucketArgs) -> Result<LogBucket> {
+		let UpsertBucketArgs { id, name, query } = args;
+		let bucket_id = {
+			let mut conn = self.conn()?;
+			conn.transaction::<i32, diesel::result::Error, _>(|conn| {
+				if let Some(existing_id) = id {
+					let affected =
+						diesel::update(log_buckets::table.filter(log_buckets::id.eq(existing_id)))
+							.set((
+								log_buckets::name.eq(&name),
+								log_buckets::query.eq(&query),
+								log_buckets::updated_at.eq(now),
+							))
+							.execute(conn)?;
+					if affected > 0 {
+						Ok(existing_id)
+					} else {
+						insert_into(log_buckets::table)
+							.values(NewLogBucketRecord {
+								name: name.clone(),
+								query: query.clone(),
+							})
+							.execute(conn)?;
+						let inserted_id = log_buckets::table
+							.filter(log_buckets::name.eq(&name))
+							.select(log_buckets::id)
+							.first::<i32>(conn)?;
+						Ok(inserted_id)
+					}
+				} else {
+					insert_into(log_buckets::table)
+						.values(NewLogBucketRecord {
+							name: name.clone(),
+							query: query.clone(),
+						})
+						.on_conflict(log_buckets::name)
+						.do_update()
+						.set((
+							log_buckets::query.eq(&query),
+							log_buckets::updated_at.eq(now),
+						))
+						.execute(conn)?;
+					let inserted_id = log_buckets::table
+						.filter(log_buckets::name.eq(&name))
+						.select(log_buckets::id)
+						.first::<i32>(conn)?;
+					Ok(inserted_id)
+				}
+			})?
+		};
+		self.get_bucket(bucket_id)
+			.await?
+			.ok_or_else(|| anyhow::anyhow!("bucket not found after upsert"))
+	}
+
+	pub async fn append_bucket_logs(
+		&self,
+		bucket_id: i32,
+		logs: &[NewBucketLogEntry],
+	) -> Result<Option<LogBucket>> {
+		if logs.is_empty() {
+			return self.get_bucket(bucket_id).await;
+		}
+		let maybe_bucket = {
+			let mut conn = self.conn()?;
+			conn.transaction::<Option<i32>, diesel::result::Error, _>(|conn| {
+				let exists = log_buckets::table
+					.filter(log_buckets::id.eq(bucket_id))
+					.select(log_buckets::id)
+					.first::<i32>(conn)
+					.optional()?;
+				let Some(id) = exists else {
+					return Ok(None);
+				};
+				let records: Vec<NewBucketLogRecord> = logs
+					.iter()
+					.map(|entry| NewBucketLogRecord {
+						bucket_id: id,
+						log_id: entry.id.clone(),
+						timestamp: entry.timestamp.clone(),
+						level: entry.level.clone(),
+						msg: entry.msg.clone(),
+						props: serde_json::to_string(&entry.props)
+							.unwrap_or_else(|_| "[]".to_string()),
+					})
+					.collect();
+				if !records.is_empty() {
+					insert_or_ignore_into(bucket_logs::table)
+						.values(&records)
+						.execute(conn)?;
+					let extra_ids: Vec<i32> = bucket_logs::table
+						.select(bucket_logs::id)
+						.filter(bucket_logs::bucket_id.eq(id))
+						.order(bucket_logs::created_at.desc())
+						.offset(MAX_BUCKET_ENTRIES as i64)
+						.load::<i32>(conn)?;
+					if !extra_ids.is_empty() {
+						diesel::delete(
+							bucket_logs::table.filter(bucket_logs::id.eq_any(extra_ids)),
+						)
+						.execute(conn)?;
+					}
+				}
+				diesel::update(log_buckets::table.filter(log_buckets::id.eq(id)))
+					.set(log_buckets::updated_at.eq(now))
+					.execute(conn)?;
+				Ok(Some(id))
+			})?
+		};
+		match maybe_bucket {
+			Some(id) => self.get_bucket(id).await,
+			None => Ok(None),
+		}
+	}
+
+	pub async fn clear_bucket_logs(&self, bucket_id: i32) -> Result<Option<LogBucket>> {
+		let maybe_bucket = {
+			let mut conn = self.conn()?;
+			conn.transaction::<Option<i32>, diesel::result::Error, _>(|conn| {
+				let exists = log_buckets::table
+					.filter(log_buckets::id.eq(bucket_id))
+					.select(log_buckets::id)
+					.first::<i32>(conn)
+					.optional()?;
+				let Some(id) = exists else {
+					return Ok(None);
+				};
+				diesel::delete(bucket_logs::table.filter(bucket_logs::bucket_id.eq(id)))
+					.execute(conn)?;
+				diesel::update(log_buckets::table.filter(log_buckets::id.eq(id)))
+					.set(log_buckets::updated_at.eq(now))
+					.execute(conn)?;
+				Ok(Some(id))
+			})?
+		};
+		match maybe_bucket {
+			Some(id) => self.get_bucket(id).await,
+			None => Ok(None),
+		}
+	}
+
+	pub async fn delete_bucket(&self, bucket_id: i32) -> Result<bool> {
+		let deleted = {
+			let mut conn = self.conn()?;
+			conn.transaction::<usize, diesel::result::Error, _>(|conn| {
+				diesel::delete(bucket_logs::table.filter(bucket_logs::bucket_id.eq(bucket_id)))
+					.execute(conn)?;
+				diesel::delete(log_buckets::table.filter(log_buckets::id.eq(bucket_id)))
+					.execute(conn)
+			})?
+		};
+		Ok(deleted > 0)
 	}
 
 	pub async fn update_device_stats(
@@ -808,6 +1154,7 @@ pub fn run_migrations(conn: &mut SqliteConnection) -> Result<()> {
 mod tests {
 	use super::*;
 	use puppylog::Prop;
+	use std::collections::HashSet;
 
 	fn test_db() -> DB {
 		let pool = establish_pool(":memory:").unwrap();
@@ -821,12 +1168,12 @@ mod tests {
 	async fn delete_segment_removes_props() {
 		let db = test_db();
 
-		let now = Utc::now();
+		let current_time = Utc::now();
 		let segment = db
 			.new_segment(NewSegmentArgs {
 				device_id: None,
-				first_timestamp: now,
-				last_timestamp: now,
+				first_timestamp: current_time,
+				last_timestamp: current_time,
 				original_size: 1,
 				compressed_size: 1,
 				logs_count: 1,
@@ -853,9 +1200,9 @@ mod tests {
 	async fn find_segments_overlap_start_inside_segment() {
 		let db = test_db();
 
-		let now = Utc::now();
-		let first_ts = now - chrono::Duration::hours(2);
-		let last_ts = now - chrono::Duration::hours(1);
+		let current_time = Utc::now();
+		let first_ts = current_time - chrono::Duration::hours(2);
+		let last_ts = current_time - chrono::Duration::hours(1);
 		let seg_id = db
 			.new_segment(NewSegmentArgs {
 				device_id: None,
@@ -870,8 +1217,8 @@ mod tests {
 
 		let metas = db
 			.find_segments(&GetSegmentsQuery {
-				start: Some(now - chrono::Duration::minutes(90)),
-				end: Some(now),
+				start: Some(current_time - chrono::Duration::minutes(90)),
+				end: Some(current_time),
 				device_ids: None,
 				count: None,
 				sort: None,
@@ -885,13 +1232,13 @@ mod tests {
 	#[tokio::test]
 	async fn find_segments_without_device() {
 		let db = test_db();
-		let now = Utc::now();
+		let current_time = Utc::now();
 
 		let no_dev = db
 			.new_segment(NewSegmentArgs {
 				device_id: None,
-				first_timestamp: now,
-				last_timestamp: now,
+				first_timestamp: current_time,
+				last_timestamp: current_time,
 				original_size: 1,
 				compressed_size: 1,
 				logs_count: 1,
@@ -902,8 +1249,8 @@ mod tests {
 		let _with_dev = db
 			.new_segment(NewSegmentArgs {
 				device_id: Some("dev1".into()),
-				first_timestamp: now,
-				last_timestamp: now,
+				first_timestamp: current_time,
+				last_timestamp: current_time,
 				original_size: 1,
 				compressed_size: 1,
 				logs_count: 1,
@@ -920,9 +1267,9 @@ mod tests {
 	#[tokio::test]
 	async fn prev_segment_end_filters_device() {
 		let db = test_db();
-		let now = Utc::now();
-		let ts_dev1 = now - chrono::Duration::hours(30);
-		let ts_dev2 = now - chrono::Duration::hours(5);
+		let current_time = Utc::now();
+		let ts_dev1 = current_time - chrono::Duration::hours(30);
+		let ts_dev2 = current_time - chrono::Duration::hours(5);
 
 		db.new_segment(NewSegmentArgs {
 			device_id: Some("dev1".into()),
@@ -947,11 +1294,102 @@ mod tests {
 		.unwrap();
 
 		let found = db
-			.prev_segment_end(Some(&now), Some(&["dev1".to_string()]))
+			.prev_segment_end(Some(&current_time), Some(&["dev1".to_string()]))
 			.await
 			.unwrap()
 			.unwrap();
 
 		assert_eq!(found, ts_dev1);
+	}
+
+	#[tokio::test]
+	async fn bucket_crud_flow() {
+		let db = test_db();
+		let bucket = db
+			.upsert_bucket(UpsertBucketArgs {
+				id: None,
+				name: "Errors".into(),
+				query: "level:error".into(),
+			})
+			.await
+			.unwrap();
+		assert_eq!(bucket.logs.len(), 0);
+
+		let ts = Utc::now().to_rfc3339();
+		let updated = db
+			.append_bucket_logs(
+				bucket.id,
+				&[NewBucketLogEntry {
+					id: "log-1".into(),
+					timestamp: ts.clone(),
+					level: "error".into(),
+					msg: "something failed".into(),
+					props: vec![BucketProp {
+						key: "device".into(),
+						value: "alpha".into(),
+					}],
+				}],
+			)
+			.await
+			.unwrap()
+			.expect("bucket exists");
+		assert_eq!(updated.logs.len(), 1);
+		assert_eq!(updated.logs[0].id, "log-1");
+
+		let listed = db.list_buckets().await.unwrap();
+		assert_eq!(listed.len(), 1);
+		assert_eq!(listed[0].name, "Errors");
+		assert_eq!(listed[0].logs.len(), 1);
+
+		let cleared = db
+			.clear_bucket_logs(bucket.id)
+			.await
+			.unwrap()
+			.expect("bucket cleared");
+		assert_eq!(cleared.logs.len(), 0);
+
+		let deleted = db.delete_bucket(bucket.id).await.unwrap();
+		assert!(deleted);
+		assert!(db.list_buckets().await.unwrap().is_empty());
+	}
+
+	#[tokio::test]
+	async fn bucket_log_limit_and_deduplication() {
+		let db = test_db();
+		let bucket = db
+			.upsert_bucket(UpsertBucketArgs {
+				id: None,
+				name: "Recent".into(),
+				query: "host:web".into(),
+			})
+			.await
+			.unwrap();
+
+		let mut entries = Vec::new();
+		for i in 0..(BUCKET_LOG_LIMIT + 25) {
+			entries.push(NewBucketLogEntry {
+				id: format!("log-{i}"),
+				timestamp: (Utc::now() + chrono::Duration::seconds(i as i64)).to_rfc3339(),
+				level: "info".into(),
+				msg: format!("message {i}"),
+				props: vec![],
+			});
+		}
+
+		db.append_bucket_logs(bucket.id, &entries)
+			.await
+			.unwrap()
+			.expect("bucket exists");
+
+		// Re-append first few entries to ensure they are deduplicated
+		db.append_bucket_logs(bucket.id, &entries[..10])
+			.await
+			.unwrap()
+			.expect("bucket exists");
+
+		let refreshed = db.get_bucket(bucket.id).await.unwrap().unwrap();
+		assert_eq!(refreshed.logs.len(), BUCKET_LOG_LIMIT);
+		let unique: HashSet<&str> = refreshed.logs.iter().map(|log| log.id.as_str()).collect();
+		assert_eq!(unique.len(), refreshed.logs.len());
 	}
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -131,6 +131,25 @@ async fn main() {
 		.with_state(ctx.clone())
 		.route("/api/v1/segments", get(controllers::get_segments))
 		.with_state(ctx.clone())
+		.route("/api/v1/buckets", get(controllers::list_buckets))
+		.with_state(ctx.clone())
+		.route("/api/v1/buckets", post(controllers::upsert_bucket))
+		.with_state(ctx.clone())
+		.route(
+			"/api/v1/buckets/{bucketId}/logs",
+			post(controllers::append_bucket_logs),
+		)
+		.with_state(ctx.clone())
+		.route(
+			"/api/v1/buckets/{bucketId}/clear",
+			post(controllers::clear_bucket_logs),
+		)
+		.with_state(ctx.clone())
+		.route(
+			"/api/v1/buckets/{bucketId}",
+			delete(controllers::delete_bucket),
+		)
+		.with_state(ctx.clone())
 		.route("/api/v1/segment/{segmentId}", get(controllers::get_segment))
 		.with_state(ctx.clone())
 		.route(

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -20,10 +20,10 @@ diesel::table! {
 }
 
 diesel::table! {
-	log_segments (id) {
-		id -> Integer,
-		bucket_id -> Nullable<Integer>,
-		device_id -> Nullable<Text>,
+		log_segments (id) {
+				id -> Integer,
+				bucket_id -> Nullable<Integer>,
+				device_id -> Nullable<Text>,
 		first_timestamp -> Timestamp,
 		last_timestamp -> Timestamp,
 		original_size -> BigInt,
@@ -34,11 +34,34 @@ diesel::table! {
 }
 
 diesel::table! {
-	segment_props (segment_id, key, value) {
-		segment_id -> Integer,
-		key -> Text,
-		value -> Text,
-	}
+		log_buckets (id) {
+				id -> Integer,
+				name -> Text,
+				query -> Text,
+				created_at -> Timestamp,
+				updated_at -> Timestamp,
+		}
+}
+
+diesel::table! {
+		bucket_logs (id) {
+				id -> Integer,
+				bucket_id -> Integer,
+				log_id -> Text,
+				timestamp -> Text,
+				level -> Text,
+				msg -> Text,
+				props -> Text,
+				created_at -> Timestamp,
+		}
+}
+
+diesel::table! {
+		segment_props (segment_id, key, value) {
+				segment_id -> Integer,
+				key -> Text,
+				value -> Text,
+		}
 }
 
 diesel::table! {
@@ -50,8 +73,10 @@ diesel::table! {
 }
 
 diesel::allow_tables_to_appear_in_same_query!(
+	bucket_logs,
 	devices,
 	device_props,
+	log_buckets,
 	log_segments,
 	segment_props,
 	migrations,

--- a/ts/app.ts
+++ b/ts/app.ts
@@ -9,6 +9,7 @@ import { settingsPage } from "./settings"
 import { Container } from "./ui"
 import { queriesPage } from "./queries"
 import { serverPage } from "./server"
+import { bucketsPage } from "./buckets"
 
 window.onload = () => {
 	const body = document.querySelector("body")
@@ -23,6 +24,7 @@ window.onload = () => {
 		"/devices": () => devicesPage(body),
 		"/device/:deviceId": (params: any) => devicePage(body, params.deviceId),
 		"/segments": () => segmentsPage(container),
+		"/buckets": () => bucketsPage(body),
 		"/queries": () => queriesPage(body),
 		"/segment/:segmentId": (params: any) =>
 			segmentPage(body, params.segmentId),

--- a/ts/buckets.ts
+++ b/ts/buckets.ts
@@ -1,0 +1,213 @@
+import { showModal } from "./common"
+import { formatLogMsg } from "./logmsg"
+import { navigate } from "./router"
+import { Navbar } from "./navbar"
+import {
+	clearBucketLogs,
+	deleteBucket,
+	listBuckets,
+	MAX_BUCKET_ENTRIES,
+} from "./log-buckets"
+import type { LogBucket } from "./log-buckets"
+
+const formatTimestamp = (value: string): string => {
+	const date = new Date(value)
+	if (Number.isNaN(date.getTime())) return "unknown time"
+	const yyyy = date.getFullYear()
+	const mm = String(date.getMonth() + 1).padStart(2, "0")
+	const dd = String(date.getDate()).padStart(2, "0")
+	const hh = String(date.getHours()).padStart(2, "0")
+	const mi = String(date.getMinutes()).padStart(2, "0")
+	const ss = String(date.getSeconds()).padStart(2, "0")
+	return `${yyyy}-${mm}-${dd} ${hh}:${mi}:${ss}`
+}
+
+const truncate = (value: string, length: number): string =>
+	value.length > length ? `${value.slice(0, length)}…` : value
+
+const emptyMessage = () => {
+	const empty = document.createElement("div")
+	empty.textContent =
+		"No buckets yet. Collect logs from the search page to populate this view."
+	empty.style.color = "#6b7280"
+	empty.style.fontStyle = "italic"
+	return empty
+}
+
+const buildActions = (bucket: LogBucket, refresh: () => Promise<void>) => {
+	const actions = document.createElement("div")
+	actions.style.display = "flex"
+	actions.style.gap = "8px"
+	actions.style.flexWrap = "wrap"
+
+	const openButton = document.createElement("button")
+	openButton.textContent = "Open in search"
+	openButton.onclick = () =>
+		navigate(`/?query=${encodeURIComponent(bucket.query)}`)
+	actions.appendChild(openButton)
+
+	const clearButton = document.createElement("button")
+	clearButton.textContent = "Clear logs"
+	clearButton.onclick = () => {
+		void (async () => {
+			try {
+				await clearBucketLogs(bucket.id)
+				await refresh()
+			} catch (error) {
+				console.error("Failed to clear bucket", error)
+				window.alert("Failed to clear bucket logs. Please try again.")
+			}
+		})()
+	}
+	actions.appendChild(clearButton)
+
+	const deleteButton = document.createElement("button")
+	deleteButton.textContent = "Delete bucket"
+	deleteButton.onclick = () => {
+		if (
+			window.confirm(
+				`Delete bucket "${bucket.name}"? This only removes the copies.`,
+			)
+		) {
+			void (async () => {
+				try {
+					await deleteBucket(bucket.id)
+					await refresh()
+				} catch (error) {
+					console.error("Failed to delete bucket", error)
+					window.alert("Failed to delete bucket. Please try again.")
+				}
+			})()
+		}
+	}
+	actions.appendChild(deleteButton)
+
+	return actions
+}
+
+const buildLogList = (bucket: LogBucket) => {
+	const list = document.createElement("ul")
+	list.style.display = "flex"
+	list.style.flexDirection = "column"
+	list.style.gap = "6px"
+
+	bucket.logs.forEach((entry) => {
+		const item = document.createElement("li")
+		item.style.listStyle = "none"
+		item.style.padding = "8px"
+		item.style.border = "1px solid #e5e7eb"
+		item.style.borderRadius = "4px"
+		item.style.cursor = "pointer"
+
+		const header = document.createElement("div")
+		header.textContent = `${formatTimestamp(entry.timestamp)} · ${entry.level.toUpperCase()}`
+		header.style.fontSize = "12px"
+		header.style.color = "#374151"
+		item.appendChild(header)
+
+		if (entry.props.length > 0) {
+			const propsLine = document.createElement("div")
+			propsLine.textContent = entry.props
+				.map((prop) => `${prop.key}=${prop.value}`)
+				.join(" ")
+			propsLine.style.fontSize = "12px"
+			propsLine.style.color = "#6b7280"
+			item.appendChild(propsLine)
+		}
+
+		const message = document.createElement("div")
+		message.textContent = truncate(entry.msg, 160)
+		message.style.whiteSpace = "pre-wrap"
+		item.appendChild(message)
+
+		item.onclick = () =>
+			showModal({
+				title: "Log Message",
+				content: formatLogMsg(entry.msg),
+				footer: [],
+			})
+		list.appendChild(item)
+	})
+
+	return list
+}
+
+export const bucketsPage = (root: HTMLElement) => {
+	root.innerHTML = ""
+	const navbar = new Navbar()
+	root.appendChild(navbar.root)
+	const container = document.createElement("div")
+	container.style.display = "flex"
+	container.style.flexDirection = "column"
+	container.style.gap = "12px"
+	container.style.padding = "16px"
+	root.appendChild(container)
+
+	const render = async () => {
+		container.innerHTML = ""
+		const loading = document.createElement("div")
+		loading.textContent = "Loading buckets…"
+		loading.style.color = "#6b7280"
+		container.appendChild(loading)
+
+		let buckets: LogBucket[] = []
+		try {
+			buckets = await listBuckets()
+		} catch (error) {
+			console.error("Failed to load buckets", error)
+			container.innerHTML = ""
+			const errorNotice = document.createElement("div")
+			errorNotice.textContent =
+				"Failed to load buckets. Please try again later."
+			errorNotice.style.color = "#dc2626"
+			container.appendChild(errorNotice)
+			return
+		}
+
+		container.innerHTML = ""
+		if (buckets.length === 0) {
+			container.appendChild(emptyMessage())
+			return
+		}
+
+		buckets.forEach((bucket) => {
+			const section = document.createElement("section")
+			section.style.display = "flex"
+			section.style.flexDirection = "column"
+			section.style.gap = "8px"
+			section.style.border = "1px solid #e5e7eb"
+			section.style.borderRadius = "6px"
+			section.style.padding = "12px"
+			container.appendChild(section)
+
+			const title = document.createElement("div")
+			title.textContent = `${bucket.name} · ${bucket.logs.length}/${MAX_BUCKET_ENTRIES} logs`
+			title.style.fontWeight = "600"
+			section.appendChild(title)
+
+			const query = document.createElement("div")
+			query.textContent = bucket.query
+				? `Query: ${bucket.query}`
+				: "Query: (none)"
+			query.style.fontSize = "12px"
+			query.style.color = "#6b7280"
+			section.appendChild(query)
+
+			section.appendChild(buildActions(bucket, render))
+
+			if (bucket.logs.length === 0) {
+				const empty = document.createElement("div")
+				empty.textContent = "Bucket is empty."
+				empty.style.color = "#6b7280"
+				section.appendChild(empty)
+				return
+			}
+
+			section.appendChild(buildLogList(bucket))
+		})
+	}
+
+	void render()
+
+	return root
+}

--- a/ts/common.ts
+++ b/ts/common.ts
@@ -12,7 +12,7 @@ export const showModal = (args: {
 	minWidth?: number
 	content: HTMLElement
 	footer: UiComponent<HTMLElement>[]
-}) => {
+}): (() => void) => {
 	const body = document.querySelector("body")
 
 	const modalOverlay = document.createElement("div")
@@ -67,4 +67,8 @@ export const showModal = (args: {
 	})
 
 	modalOverlay.appendChild(modalContent)
+
+	return () => {
+		modalOverlay.remove()
+	}
 }

--- a/ts/log-buckets.ts
+++ b/ts/log-buckets.ts
@@ -1,0 +1,231 @@
+const API_BASE = "/api/v1/buckets"
+
+export const MAX_BUCKET_ENTRIES = 200
+
+export type BucketProp = {
+	key: string
+	value: string
+}
+
+export type BucketLogEntry = {
+	id: string
+	timestamp: string
+	level: "trace" | "debug" | "info" | "warn" | "error" | "fatal"
+	msg: string
+	props: BucketProp[]
+}
+
+export type LogBucket = {
+	id: string
+	name: string
+	query: string
+	createdAt: string
+	updatedAt: string
+	logs: BucketLogEntry[]
+}
+
+type BucketResponse = {
+	id: number | string
+	name: string
+	query: string
+	createdAt: string
+	updatedAt: string
+	logs: BucketLogEntryResponse[]
+}
+
+type BucketLogEntryResponse = {
+	id: string
+	timestamp: string
+	level: string
+	msg: string
+	props: BucketPropResponse[]
+}
+
+type BucketPropResponse = {
+	key: string
+	value: string
+}
+
+type UpsertRequest = {
+	id?: number
+	name: string
+	query: string
+}
+
+type AppendLogsRequest = {
+	logs: BucketLogEntry[]
+}
+
+const isLogLevel = (value: string): value is BucketLogEntry["level"] =>
+	["trace", "debug", "info", "warn", "error", "fatal"].includes(value)
+
+const normalizeProp = (prop: BucketPropResponse): BucketProp | null => {
+	if (typeof prop !== "object" || prop === null) return null
+	if (typeof prop.key !== "string" || prop.key.trim() === "") return null
+	if (typeof prop.value !== "string") return null
+	return {
+		key: prop.key,
+		value: prop.value,
+	}
+}
+
+const normalizeLogEntry = (
+	entry: BucketLogEntryResponse,
+): BucketLogEntry | null => {
+	if (typeof entry !== "object" || entry === null) return null
+	if (typeof entry.id !== "string" || entry.id === "") return null
+	if (typeof entry.timestamp !== "string" || entry.timestamp === "")
+		return null
+	const level =
+		typeof entry.level === "string" && isLogLevel(entry.level)
+			? entry.level
+			: null
+	if (!level) return null
+	const props = Array.isArray(entry.props)
+		? entry.props
+				.map(normalizeProp)
+				.filter((prop): prop is BucketProp => Boolean(prop))
+		: []
+	return {
+		id: entry.id,
+		timestamp: entry.timestamp,
+		level,
+		msg: typeof entry.msg === "string" ? entry.msg : "",
+		props,
+	}
+}
+
+const normalizeBucket = (bucket: BucketResponse): LogBucket | null => {
+	if (typeof bucket !== "object" || bucket === null) return null
+	if (typeof bucket.name !== "string" || bucket.name.trim() === "")
+		return null
+	const id = typeof bucket.id === "number" ? bucket.id.toString() : bucket.id
+	if (typeof id !== "string" || id === "") return null
+	const query = typeof bucket.query === "string" ? bucket.query : ""
+	const createdAt =
+		typeof bucket.createdAt === "string"
+			? bucket.createdAt
+			: new Date().toISOString()
+	const updatedAt =
+		typeof bucket.updatedAt === "string" ? bucket.updatedAt : createdAt
+	const logs = Array.isArray(bucket.logs)
+		? bucket.logs
+				.map(normalizeLogEntry)
+				.filter((entry): entry is BucketLogEntry => Boolean(entry))
+		: []
+	return {
+		id,
+		name: bucket.name,
+		query,
+		createdAt,
+		updatedAt,
+		logs,
+	}
+}
+
+const handleResponse = async <T>(response: Response): Promise<T> => {
+	if (response.status === 204) {
+		return null as T
+	}
+	if (!response.ok) {
+		throw new Error(`Bucket request failed: ${response.status}`)
+	}
+	return (await response.json()) as T
+}
+
+export const listBuckets = async (): Promise<LogBucket[]> => {
+	const response = await fetch(API_BASE, {
+		headers: { Accept: "application/json" },
+	})
+	const data = await handleResponse<unknown>(response)
+	if (!Array.isArray(data)) return []
+	return data
+		.map((item) => normalizeBucket(item as BucketResponse))
+		.filter((bucket): bucket is LogBucket => Boolean(bucket))
+}
+
+const prepareUpsertPayload = (args: {
+	id?: string
+	name: string
+	query: string
+}): UpsertRequest => {
+	const payload: UpsertRequest = {
+		name: args.name,
+		query: args.query,
+	}
+	if (args.id !== undefined) {
+		const parsed = Number.parseInt(args.id, 10)
+		if (!Number.isNaN(parsed)) payload.id = parsed
+	}
+	return payload
+}
+
+const sendBucketRequest = async (
+	url: string,
+	init: RequestInit,
+): Promise<LogBucket | null> => {
+	const response = await fetch(url, {
+		headers: {
+			"Content-Type": "application/json",
+			Accept: "application/json",
+		},
+		...init,
+	})
+	if (response.status === 404) return null
+	const data = await handleResponse<unknown>(response)
+	if (!data) return null
+	const bucket = normalizeBucket(data as BucketResponse)
+	if (!bucket) throw new Error("Received malformed bucket from server")
+	return bucket
+}
+
+export const upsertBucket = async (args: {
+	id?: string
+	name: string
+	query: string
+}): Promise<LogBucket> => {
+	const bucket = await sendBucketRequest(API_BASE, {
+		method: "POST",
+		body: JSON.stringify(prepareUpsertPayload(args)),
+	})
+	if (!bucket) throw new Error("Failed to create or update bucket")
+	return bucket
+}
+
+export const appendLogsToBucket = async (
+	bucketId: string,
+	logs: BucketLogEntry[],
+	_limit = MAX_BUCKET_ENTRIES,
+): Promise<LogBucket | null> => {
+	const payload: AppendLogsRequest = {
+		logs,
+	}
+	return sendBucketRequest(
+		`${API_BASE}/${encodeURIComponent(bucketId)}/logs`,
+		{
+			method: "POST",
+			body: JSON.stringify(payload),
+		},
+	)
+}
+
+export const clearBucketLogs = async (
+	bucketId: string,
+): Promise<LogBucket | null> =>
+	sendBucketRequest(`${API_BASE}/${encodeURIComponent(bucketId)}/clear`, {
+		method: "POST",
+		body: "",
+	})
+
+export const deleteBucket = async (bucketId: string): Promise<boolean> => {
+	const response = await fetch(
+		`${API_BASE}/${encodeURIComponent(bucketId)}`,
+		{
+			method: "DELETE",
+		},
+	)
+	if (response.status === 404) return false
+	if (!response.ok)
+		throw new Error(`Failed to delete bucket: ${response.status}`)
+	return true
+}

--- a/ts/logs.ts
+++ b/ts/logs.ts
@@ -1,10 +1,17 @@
 import { showModal } from "./common"
 import { formatLogMsg } from "./logmsg"
 import { saveQuery } from "./queries"
-import { Collapsible, VList } from "./ui"
+import { Button, Collapsible, VList } from "./ui"
 import { Histogram, HistogramItem } from "./histogram"
 import { getQueryParam, removeQueryParam, setQueryParam } from "./utility"
 import { Navbar } from "./navbar"
+import {
+	appendLogsToBucket,
+	listBuckets,
+	MAX_BUCKET_ENTRIES,
+	upsertBucket,
+} from "./log-buckets"
+import type { BucketLogEntry, LogBucket } from "./log-buckets"
 
 export type LogLevel = "trace" | "debug" | "info" | "warn" | "error" | "fatal"
 
@@ -157,6 +164,7 @@ const truncateMessage = (msg: string): string =>
 export const logsSearchPage = (args: LogsSearchPageArgs) => {
 	const logIds = new Set<string>()
 	const logEntries: LogEntry[] = []
+	let activeBucket: LogBucket | null = null
 	args.root.innerHTML = ``
 
 	const navbar = new Navbar()
@@ -193,6 +201,276 @@ export const logsSearchPage = (args: LogsSearchPageArgs) => {
 	searchControls.className = "logs-search-controls"
 	searchControls.append(searchButton, stopButton)
 	rightPanel.append(searchControls)
+
+	const bucketControls = document.createElement("div")
+	bucketControls.className = "logs-bucket-controls"
+	bucketControls.style.display = "flex"
+	bucketControls.style.alignItems = "center"
+	bucketControls.style.marginLeft = "8px"
+
+	const bucketButton = document.createElement("button")
+	bucketButton.className = "logs-bucket-button"
+	bucketButton.textContent = "Collect logs"
+	bucketButton.setAttribute("aria-pressed", "false")
+	bucketControls.appendChild(bucketButton)
+	rightPanel.appendChild(bucketControls)
+
+	const bucketBanner = document.createElement("div")
+	bucketBanner.className = "logs-bucket-banner"
+	bucketBanner.style.display = "none"
+	bucketBanner.style.margin = "8px 0"
+	bucketBanner.style.padding = "8px 16px"
+	bucketBanner.style.background = "#e0f2fe"
+	bucketBanner.style.borderRadius = "4px"
+	bucketBanner.style.fontSize = "12px"
+	bucketBanner.style.color = "#1f2937"
+	args.root.appendChild(bucketBanner)
+
+	const cloneEntriesForBucket = (
+		entries: ReadonlyArray<LogEntry>,
+	): BucketLogEntry[] =>
+		entries.map((entry) => ({
+			id: entry.id,
+			timestamp: entry.timestamp,
+			level: entry.level,
+			msg: entry.msg,
+			props: entry.props.map((prop) => ({
+				key: prop.key,
+				value: prop.value,
+			})),
+		}))
+
+	const updateBucketUI = () => {
+		if (!activeBucket) {
+			bucketButton.textContent = "Collect logs"
+			bucketButton.setAttribute("aria-pressed", "false")
+			bucketButton.title = "Copy future log lines into a named bucket"
+			bucketBanner.style.display = "none"
+			bucketBanner.textContent = ""
+			return
+		}
+		bucketButton.textContent = `Collecting (${activeBucket.name})`
+		bucketButton.setAttribute("aria-pressed", "true")
+		const count = activeBucket.logs.length
+		const query = activeBucket.query
+			? `“${activeBucket.query}”`
+			: "current search"
+		bucketBanner.textContent = `Collecting ${count}/${MAX_BUCKET_ENTRIES} logs into "${activeBucket.name}" for ${query}.`
+		bucketBanner.style.display = "flex"
+		bucketBanner.style.alignItems = "center"
+	}
+
+	const startCollecting = async (
+		bucket: LogBucket,
+		copyExisting: boolean,
+	) => {
+		let workingBucket = bucket
+		if (copyExisting && logEntries.length > 0) {
+			const clones = cloneEntriesForBucket(
+				logEntries.slice(0, MAX_BUCKET_ENTRIES),
+			)
+			try {
+				const updated = await appendLogsToBucket(bucket.id, clones)
+				if (updated) workingBucket = updated
+			} catch (error) {
+				console.error("Failed to append logs to bucket", error)
+			}
+		}
+		activeBucket = workingBucket
+		updateBucketUI()
+	}
+
+	const stopCollecting = () => {
+		activeBucket = null
+		updateBucketUI()
+	}
+
+	const handleBucketSelection = async (
+		bucket: LogBucket,
+		close: () => void,
+		setError: (message: string) => void,
+	) => {
+		try {
+			const updated = await upsertBucket({
+				id: bucket.id,
+				name: bucket.name,
+				query: searchTextarea.value,
+			})
+			await startCollecting(updated, true)
+			close()
+		} catch (error) {
+			console.error("Failed to activate bucket", error)
+			setError("Failed to activate bucket. Please try again.")
+		}
+	}
+
+	const openBucketModal = async () => {
+		let closeModal: () => void = () => {}
+		const container = document.createElement("div")
+		container.style.display = "flex"
+		container.style.flexDirection = "column"
+		container.style.gap = "12px"
+
+		const description = document.createElement("p")
+		description.textContent =
+			"Buckets store a copy of matching log lines for quick access."
+		description.style.margin = "0"
+		container.appendChild(description)
+
+		const existingTitle = document.createElement("h4")
+		existingTitle.textContent = "Use an existing bucket"
+		existingTitle.style.margin = "0"
+		container.appendChild(existingTitle)
+
+		const errorText = document.createElement("span")
+		errorText.style.color = "#dc2626"
+		errorText.style.fontSize = "12px"
+		errorText.style.minHeight = "16px"
+
+		const existingList = document.createElement("div")
+		existingList.style.display = "flex"
+		existingList.style.flexDirection = "column"
+		existingList.style.gap = "8px"
+		container.appendChild(existingList)
+
+		let buckets: LogBucket[] = []
+		let loadError: string | null = null
+		try {
+			buckets = await listBuckets()
+		} catch (error) {
+			console.error("Failed to load buckets", error)
+			loadError = "Unable to load buckets from the server."
+		}
+
+		if (loadError) {
+			const failed = document.createElement("span")
+			failed.textContent = loadError
+			failed.style.color = "#dc2626"
+			existingList.appendChild(failed)
+		} else if (buckets.length === 0) {
+			const empty = document.createElement("span")
+			empty.textContent = "No buckets yet."
+			empty.style.color = "#6b7280"
+			existingList.appendChild(empty)
+		} else {
+			buckets.forEach((bucket) => {
+				const option = document.createElement("button")
+				option.type = "button"
+				option.textContent = `${bucket.name} (${bucket.logs.length})`
+				option.style.display = "flex"
+				option.style.justifyContent = "space-between"
+				option.style.alignItems = "center"
+				option.style.padding = "6px 10px"
+				option.style.border = "1px solid #d1d5db"
+				option.style.borderRadius = "4px"
+				option.style.background = "white"
+				option.style.cursor = "pointer"
+				if (activeBucket && bucket.id === activeBucket.id) {
+					option.style.background = "#e0f2fe"
+				}
+				option.onclick = () =>
+					handleBucketSelection(
+						bucket,
+						() => closeModal(),
+						(message) => {
+							errorText.textContent = message
+						},
+					)
+				existingList.appendChild(option)
+			})
+		}
+
+		const createSection = document.createElement("div")
+		createSection.style.display = "flex"
+		createSection.style.flexDirection = "column"
+		createSection.style.gap = "8px"
+
+		const createTitle = document.createElement("h4")
+		createTitle.textContent = "Create a new bucket"
+		createTitle.style.margin = "0"
+		createSection.appendChild(createTitle)
+
+		const nameInput = document.createElement("input")
+		nameInput.type = "text"
+		nameInput.placeholder = "Bucket name"
+		nameInput.autocomplete = "off"
+		nameInput.style.padding = "6px"
+		nameInput.style.border = "1px solid #d1d5db"
+		nameInput.style.borderRadius = "4px"
+		createSection.appendChild(nameInput)
+
+		const helper = document.createElement("span")
+		helper.textContent = `Each bucket keeps up to ${MAX_BUCKET_ENTRIES} log lines.`
+		helper.style.fontSize = "12px"
+		helper.style.color = "#6b7280"
+		createSection.appendChild(helper)
+
+		createSection.appendChild(errorText)
+
+		const createButton = document.createElement("button")
+		createButton.type = "button"
+		createButton.textContent = "Create & collect"
+		createButton.style.alignSelf = "flex-start"
+		createButton.style.padding = "6px 12px"
+		createButton.style.border = "1px solid #2563eb"
+		createButton.style.background = "#2563eb"
+		createButton.style.color = "white"
+		createButton.style.borderRadius = "4px"
+		createButton.style.cursor = "pointer"
+		createSection.appendChild(createButton)
+
+		container.appendChild(createSection)
+
+		const closeButton = new Button({ text: "Close" })
+		const footerButtons: Button[] = []
+		if (activeBucket) {
+			const stopButton = new Button({ text: "Stop collecting" })
+			stopButton.onClick = () => {
+				stopCollecting()
+				closeModal()
+			}
+			footerButtons.push(stopButton)
+		}
+		footerButtons.push(closeButton)
+
+		closeModal = showModal({
+			title: "Collect logs in a bucket",
+			minWidth: 360,
+			content: container,
+			footer: footerButtons,
+		})
+
+		closeButton.onClick = () => closeModal()
+
+		createButton.onclick = () => {
+			errorText.textContent = ""
+			const name = nameInput.value.trim()
+			if (!name) {
+				errorText.textContent = "Please provide a bucket name."
+				return
+			}
+			void (async () => {
+				try {
+					const bucket = await upsertBucket({
+						name,
+						query: searchTextarea.value,
+					})
+					await startCollecting(bucket, true)
+					closeModal()
+				} catch (error) {
+					console.error("Failed to create bucket", error)
+					errorText.textContent =
+						"Failed to create bucket. Please try again."
+				}
+			})()
+		}
+	}
+
+	updateBucketUI()
+
+	bucketButton.onclick = () => {
+		void openBucketModal()
+	}
 
 	// Options dropdown (currently only histogram)
 	const featuresList = new VList()
@@ -355,6 +633,35 @@ export const logsSearchPage = (args: LogsSearchPageArgs) => {
 				logIds.add(entry.id)
 				logEntries.push(entry)
 			})
+			if (
+				activeBucket &&
+				newEntries.length > 0 &&
+				activeBucket.query === lastQuery
+			) {
+				const targetBucket = activeBucket
+				const clones = cloneEntriesForBucket(newEntries)
+				void (async () => {
+					try {
+						const updated = await appendLogsToBucket(
+							targetBucket.id,
+							clones,
+						)
+						if (
+							updated &&
+							activeBucket &&
+							updated.id === activeBucket.id
+						) {
+							activeBucket = updated
+							updateBucketUI()
+						}
+					} catch (error) {
+						console.error(
+							"Failed to append streaming logs to bucket",
+							error,
+						)
+					}
+				})()
+			}
 			logEntries.sort((a, b) => b.timestamp.localeCompare(a.timestamp))
 			if (
 				logEntries.length > MAX_LOG_ENTRIES &&
@@ -388,6 +695,21 @@ export const logsSearchPage = (args: LogsSearchPageArgs) => {
 		segmentStatus = ""
 		statsStatus = ""
 		updateProgressIndicator()
+		if (activeBucket) {
+			void (async () => {
+				try {
+					const updated = await upsertBucket({
+						id: activeBucket?.id,
+						name: activeBucket?.name || "",
+						query: searchTextarea.value,
+					})
+					activeBucket = updated
+					updateBucketUI()
+				} catch (error) {
+					console.error("Failed to refresh bucket metadata", error)
+				}
+			})()
+		}
 		return token
 	}
 

--- a/ts/navbar.ts
+++ b/ts/navbar.ts
@@ -4,6 +4,7 @@ export class Navbar extends HList {
 	public readonly logsLink: HTMLAnchorElement
 	public readonly devicesLink: HTMLAnchorElement
 	public readonly segmentsLink: HTMLAnchorElement
+	public readonly bucketsLink: HTMLAnchorElement
 	private leftItems: HTMLElement[]
 
 	constructor(args?: { right?: (HTMLElement | UiComponent<HTMLElement>)[] }) {
@@ -22,19 +23,29 @@ export class Navbar extends HList {
 		this.segmentsLink.textContent = "Segments"
 		this.segmentsLink.href = "/segments"
 		this.segmentsLink.classList.add("link")
+		this.bucketsLink = document.createElement("a")
+		this.bucketsLink.textContent = "Buckets"
+		this.bucketsLink.href = "/buckets"
+		this.bucketsLink.classList.add("link")
 		// Mark active link
 		const currentPath = window.location.pathname
 		;[
 			{ link: this.logsLink, path: "/logs" },
 			{ link: this.devicesLink, path: "/devices" },
 			{ link: this.segmentsLink, path: "/segments" },
+			{ link: this.bucketsLink, path: "/buckets" },
 		].forEach(({ link, path }) => {
 			if (currentPath === path || currentPath.startsWith(path + "/")) {
 				link.classList.add("active")
 			}
 		})
 		// prepare left items
-		this.leftItems = [this.logsLink, this.devicesLink, this.segmentsLink]
+		this.leftItems = [
+			this.logsLink,
+			this.devicesLink,
+			this.segmentsLink,
+			this.bucketsLink,
+		]
 		// initial render of left and optional right items
 		this.setRight(args?.right)
 	}


### PR DESCRIPTION
## Summary
- add SQLite-backed storage for log buckets/log copies plus Diesel helpers and tests
- expose REST endpoints for managing buckets and wire them into the main server
- update the frontend buckets workflow to use the backend API and document the contract in the README

## Testing
- cargo fmt
- cargo clippy --workspace
- cargo test --workspace
- npm run format
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_e_690480d0c6408326a9c62afb1963a808