### PR TITLE
Add Bearer API key auth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1833,6 +1833,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serial_test",
+ "sha2",
  "simple_logger",
  "tempfile",
  "tokio",
@@ -2283,6 +2284,17 @@ name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ serde_json = "1"
 futures = "0.3"
 tokio-stream = "0.1"
 bytes = "1"
+sha2 = "0.10"
 puppylog = { path = "core" }
 chrono = { workspace = true }
 log = "0.4"

--- a/README.md
+++ b/README.md
@@ -115,6 +115,16 @@ Logbatch is a binary structure which stores multiple loglines. Logbatch is compr
 
 ## API
 
+When server auth is enabled, API clients must send:
+
+```
+Authorization: Bearer <apikey>
+```
+
+Protected API endpoints return `401 Unauthorized` when the header is missing,
+uses a non-Bearer scheme, or contains a key not listed in the server config.
+`/api/v1/server_info` and the web assets remain public.
+
 ### GET /api/logs
 
 Search logs with PQL query. Returns logs in json format.
@@ -452,8 +462,10 @@ user PATH if needed.
 PuppyLog comes with a CLI called `plog`. The CLI automatically reads the
 server address from the `PUPPYLOG_ADDRESS` environment variable or the file
 `$HOME/.puppylog/config.json` when `--address` is not provided. Auth tokens can
-also be read from `PUPPYLOG_AUTH_TOKEN` or that same config file. Run `cargo run
---bin plog -- --help` to see all commands. Available commands include:
+also be read from `PUPPYLOG_AUTH_TOKEN` or that same config file, and are sent
+as `Authorization: Bearer <token>` unless the saved value already starts with
+`Bearer `. Run `cargo run --bin plog -- --help` to see all commands. Available
+commands include:
 
 | Command                   | Description                                       |
 | ------------------------- | ------------------------------------------------- |
@@ -558,6 +570,12 @@ bun x tsc --noEmit
 
 PuppyLog supports tuning of its in-memory buffering and merge batching behavior via environment variables:
 
+- **PUPPYLOG_API_KEYS**: Comma-separated API keys accepted by server Bearer auth,
+  for example `PUPPYLOG_API_KEYS=key-one,key-two`. Blank entries are ignored.
+- **PUPPYLOG_AUTH_REQUIRED**: Optional auth toggle. Truthy values are `1`,
+  `true`, `yes`, and `on`; falsey values are `0`, `false`, `no`, and `off`.
+  When unset, auth is required if `PUPPYLOG_API_KEYS` contains at least one key
+  and disabled otherwise.
 - **MERGER_MAX_IN_CORE**: Maximum number of log entries buffered in memory for device merging. Defaults to the compile-time constant `MAX_IN_CORE`.
 - **MERGER_TARGET_SEGMENT_SIZE**: Number of buffered entries per device before triggering a flush to storage. Defaults to `TARGET_SEGMENT_SIZE`.
 - **MERGER_BATCH_SIZE**: Number of orphan log segments fetched per merge iteration. Defaults to `MERGER_BATCH_SIZE`.
@@ -573,4 +591,5 @@ export MERGER_MAX_IN_CORE=1000000
 export MERGER_TARGET_SEGMENT_SIZE=300000
 export MERGER_BATCH_SIZE=2000
 export UPLOAD_FLUSH_THRESHOLD=50000
+export PUPPYLOG_API_KEYS=replace-with-a-secret-key
 ```

--- a/README.md
+++ b/README.md
@@ -115,15 +115,29 @@ Logbatch is a binary structure which stores multiple loglines. Logbatch is compr
 
 ## API
 
-When server auth is enabled, API clients must send:
+Protected API clients must send:
 
 ```
 Authorization: Bearer <apikey>
 ```
 
 Protected API endpoints return `401 Unauthorized` when the header is missing,
-uses a non-Bearer scheme, or contains a key not listed in the server config.
-`/api/v1/server_info` and the web assets remain public.
+uses a non-Bearer scheme, or contains a key that does not belong to a database
+user. API keys are owned by normal PuppyLog users. `/api/v1/server_info` and
+the web assets remain public.
+
+To create the first admin user on a new database, start the server once with
+both bootstrap variables set:
+
+```bash
+export PUPPYLOG_BOOTSTRAP_ADMIN_NAME=admin
+export PUPPYLOG_BOOTSTRAP_ADMIN_API_KEY=replace-with-a-secret-key
+```
+
+The bootstrap path only creates an admin when the users table is empty. It does
+not overwrite existing users or API keys. UI login and admin screens for
+managing users and API keys are planned next; this backend foundation keeps the
+current web assets public and protects API routes with bearer keys.
 
 ### GET /api/logs
 
@@ -570,12 +584,10 @@ bun x tsc --noEmit
 
 PuppyLog supports tuning of its in-memory buffering and merge batching behavior via environment variables:
 
-- **PUPPYLOG_API_KEYS**: Comma-separated API keys accepted by server Bearer auth,
-  for example `PUPPYLOG_API_KEYS=key-one,key-two`. Blank entries are ignored.
-- **PUPPYLOG_AUTH_REQUIRED**: Optional auth toggle. Truthy values are `1`,
-  `true`, `yes`, and `on`; falsey values are `0`, `false`, `no`, and `off`.
-  When unset, auth is required if `PUPPYLOG_API_KEYS` contains at least one key
-  and disabled otherwise.
+- **PUPPYLOG_BOOTSTRAP_ADMIN_NAME** and
+  **PUPPYLOG_BOOTSTRAP_ADMIN_API_KEY**: Optional first-admin bootstrap. When
+  both are set and the users table is empty, the server creates an admin user
+  with the supplied API key. If any user already exists, bootstrap is skipped.
 - **MERGER_MAX_IN_CORE**: Maximum number of log entries buffered in memory for device merging. Defaults to the compile-time constant `MAX_IN_CORE`.
 - **MERGER_TARGET_SEGMENT_SIZE**: Number of buffered entries per device before triggering a flush to storage. Defaults to `TARGET_SEGMENT_SIZE`.
 - **MERGER_BATCH_SIZE**: Number of orphan log segments fetched per merge iteration. Defaults to `MERGER_BATCH_SIZE`.
@@ -591,5 +603,6 @@ export MERGER_MAX_IN_CORE=1000000
 export MERGER_TARGET_SEGMENT_SIZE=300000
 export MERGER_BATCH_SIZE=2000
 export UPLOAD_FLUSH_THRESHOLD=50000
-export PUPPYLOG_API_KEYS=replace-with-a-secret-key
+export PUPPYLOG_BOOTSTRAP_ADMIN_NAME=admin
+export PUPPYLOG_BOOTSTRAP_ADMIN_API_KEY=replace-with-a-secret-key
 ```

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -139,10 +139,28 @@ fn masked_token(token: &str) -> String {
 	format!("{}****", &token[..4])
 }
 
-fn apply_auth_header(request: reqwest::RequestBuilder, token: Option<&str>) -> reqwest::RequestBuilder {
-	match token {
-		Some(token) if !token.trim().is_empty() => request.header("Authorization", token),
-		_ => request,
+fn authorization_header_value(token: &str) -> Option<String> {
+	let token = token.trim();
+	if token.is_empty() {
+		return None;
+	}
+	if token
+		.get(.."Bearer ".len())
+		.is_some_and(|scheme| scheme.eq_ignore_ascii_case("Bearer "))
+	{
+		Some(token.to_string())
+	} else {
+		Some(format!("Bearer {token}"))
+	}
+}
+
+fn apply_auth_header(
+	request: reqwest::RequestBuilder,
+	token: Option<&str>,
+) -> reqwest::RequestBuilder {
+	match token.and_then(authorization_header_value) {
+		Some(value) => request.header("Authorization", value),
+		None => request,
 	}
 }
 
@@ -728,12 +746,8 @@ enum LogsSubCommand {
 
 #[derive(Subcommand)]
 enum ConfigSubCommand {
-	SetUrl {
-		url: String,
-	},
-	SetToken {
-		token: String,
-	},
+	SetUrl { url: String },
+	SetToken { token: String },
 	Clear,
 	ClearUrl,
 	ClearToken,
@@ -912,7 +926,9 @@ async fn download_logs(
 
 	eprintln!("downloading logs: {}", url);
 	let response = apply_auth_header(
-		client.get(url).header(reqwest::header::ACCEPT, "application/json"),
+		client
+			.get(url)
+			.header(reqwest::header::ACCEPT, "application/json"),
 		auth_token,
 	)
 	.send()
@@ -949,13 +965,19 @@ async fn main() -> Result<(), Box<dyn Error>> {
 	let update_client = reqwest::Client::new();
 	let should_prompt_for_url = cli.address.is_none()
 		&& load_default_address().is_none()
-		&& !matches!(cli.subcommand, Some(Commands::Update) | Some(Commands::Config { .. }));
+		&& !matches!(
+			cli.subcommand,
+			Some(Commands::Update) | Some(Commands::Config { .. })
+		);
 
 	if should_prompt_for_url {
 		let _ = prompt_for_server_url()?;
 	}
 
-	if !matches!(&cli.subcommand, Some(Commands::Update) | Some(Commands::Config { .. })) {
+	if !matches!(
+		&cli.subcommand,
+		Some(Commands::Update) | Some(Commands::Config { .. })
+	) {
 		maybe_check_for_updates(&update_client).await;
 	}
 
@@ -994,9 +1016,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 					}
 
 					let client = reqwest::Client::new();
-					let response = client
-						.post(&addr)
-						.header("Authorization", auth.unwrap_or_default())
+					let response = apply_auth_header(client.post(&addr), auth.as_deref())
 						.body(buffer)
 						.send()
 						.await
@@ -1107,10 +1127,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 			let props = std::fs::read_to_string(args.props_path)?;
 			println!("props: {}", props);
 			let auth_token = args.auth.clone().or_else(load_default_auth_token);
-			let req = apply_auth_header(
-				Client::new().post(&args.address),
-				auth_token.as_deref(),
-			)
+			let req = apply_auth_header(Client::new().post(&args.address), auth_token.as_deref())
 				.header("Content-Type", "application/json")
 				.body(props)
 				.send()
@@ -1183,22 +1200,28 @@ async fn main() -> Result<(), Box<dyn Error>> {
 						}
 					}
 
-					let segements = apply_auth_header(client.get(url.clone()), auth_token.as_deref())
-						.send()
-						.await?
-						.json::<Vec<serde_json::Value>>()
-						.await?;
+					let segements =
+						apply_auth_header(client.get(url.clone()), auth_token.as_deref())
+							.send()
+							.await?
+							.json::<Vec<serde_json::Value>>()
+							.await?;
 
 					for segment in segements {
 						let id = segment["id"].as_i64().unwrap().to_string();
-						let url = endpoint_url(&base_addr, &format!("/api/v1/segment/{}/download", id))?;
+						let url =
+							endpoint_url(&base_addr, &format!("/api/v1/segment/{}/download", id))?;
 						let file_path = output_path.join(format!("segment_{}.zstd", id));
 						if !file_path.exists() {
 							println!("downloading: {}", url);
 							let response = loop {
-								let res = match apply_auth_header(client.get(url.clone()), auth_token.as_deref())
-									.send()
-									.await {
+								let res = match apply_auth_header(
+									client.get(url.clone()),
+									auth_token.as_deref(),
+								)
+								.send()
+								.await
+								{
 									Ok(res) => res,
 									Err(e) => {
 										eprintln!("Error downloading segment: {}", e);
@@ -1222,9 +1245,13 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
 						let url = endpoint_url(&base_addr, &format!("/api/v1/segment/{}", id))?;
 						loop {
-							let resp = match apply_auth_header(client.delete(url.clone()), auth_token.as_deref())
-								.send()
-								.await {
+							let resp = match apply_auth_header(
+								client.delete(url.clone()),
+								auth_token.as_deref(),
+							)
+							.send()
+							.await
+							{
 								Ok(r) => r,
 								Err(e) => {
 									eprintln!("Error deleting segment {}: {}", id, e);
@@ -1270,15 +1297,17 @@ async fn main() -> Result<(), Box<dyn Error>> {
 						}
 					}
 
-					let segements = apply_auth_header(client.get(url.clone()), auth_token.as_deref())
-						.send()
-						.await?
-						.json::<Vec<serde_json::Value>>()
-						.await?;
+					let segements =
+						apply_auth_header(client.get(url.clone()), auth_token.as_deref())
+							.send()
+							.await?
+							.json::<Vec<serde_json::Value>>()
+							.await?;
 
 					for segment in segements {
 						let id = segment["id"].as_i64().unwrap().to_string();
-						let url = endpoint_url(&base_addr, &format!("/api/v1/segment/{}/download", id))?;
+						let url =
+							endpoint_url(&base_addr, &format!("/api/v1/segment/{}/download", id))?;
 						let file_path = output_path.join(format!("segment_{}.zst", id));
 						if file_path.exists() {
 							println!("file already exists: {}", file_path.display());
@@ -1316,7 +1345,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 						query,
 						output.as_deref(),
 					)
-						.await?;
+					.await?;
 				}
 			}
 		}
@@ -1379,5 +1408,22 @@ mod tests {
 	fn masked_token_hides_secret_tail() {
 		assert_eq!(masked_token("abcd1234"), "abcd****");
 		assert_eq!(masked_token("abc"), "****");
+	}
+
+	#[test]
+	fn authorization_header_value_adds_bearer_scheme() {
+		assert_eq!(
+			authorization_header_value("secret").as_deref(),
+			Some("Bearer secret")
+		);
+		assert_eq!(
+			authorization_header_value("Bearer secret").as_deref(),
+			Some("Bearer secret")
+		);
+		assert_eq!(
+			authorization_header_value("bearer secret").as_deref(),
+			Some("bearer secret")
+		);
+		assert_eq!(authorization_header_value("   "), None);
 	}
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -946,7 +946,6 @@ async fn download_logs(
 		.map(format_download_line)
 		.collect::<Vec<_>>()
 		.join("\n");
-	println!("{}", content);
 	if let Some(output) = output {
 		if let Some(parent) = Path::new(output).parent() {
 			if !parent.as_os_str().is_empty() {
@@ -955,6 +954,8 @@ async fn download_logs(
 		}
 		std::fs::write(output, content)?;
 		eprintln!("saved {} logs to {}", entries.len(), output);
+	} else {
+		println!("{}", content);
 	}
 	Ok(())
 }

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,0 +1,214 @@
+use axum::body::Body;
+use axum::extract::{Request, State};
+use axum::http::{header, HeaderMap, HeaderValue, StatusCode};
+use axum::middleware::Next;
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use serde_json::json;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BearerAuthConfig {
+	required: bool,
+	allowed_api_keys: Vec<String>,
+}
+
+impl BearerAuthConfig {
+	pub fn from_env() -> Self {
+		let allowed_api_keys = std::env::var("PUPPYLOG_API_KEYS")
+			.ok()
+			.map(|value| parse_api_keys(&value))
+			.unwrap_or_default();
+		let required = std::env::var("PUPPYLOG_AUTH_REQUIRED")
+			.ok()
+			.and_then(|value| parse_bool(&value))
+			.unwrap_or(!allowed_api_keys.is_empty());
+
+		Self {
+			required,
+			allowed_api_keys,
+		}
+	}
+
+	#[cfg(test)]
+	pub fn disabled() -> Self {
+		Self {
+			required: false,
+			allowed_api_keys: Vec::new(),
+		}
+	}
+
+	#[cfg(test)]
+	pub fn required<I, S>(allowed_api_keys: I) -> Self
+	where
+		I: IntoIterator<Item = S>,
+		S: Into<String>,
+	{
+		Self {
+			required: true,
+			allowed_api_keys: allowed_api_keys.into_iter().map(Into::into).collect(),
+		}
+	}
+
+	fn allows(&self, headers: &HeaderMap) -> bool {
+		if !self.required {
+			return true;
+		}
+
+		let Some(token) = bearer_token(headers) else {
+			return false;
+		};
+
+		self.allowed_api_keys.iter().any(|key| key == token)
+	}
+}
+
+pub async fn require_bearer_auth(
+	State(config): State<BearerAuthConfig>,
+	headers: HeaderMap,
+	request: Request<Body>,
+	next: Next,
+) -> Response {
+	if config.allows(&headers) {
+		return next.run(request).await;
+	}
+
+	let mut response = (
+		StatusCode::UNAUTHORIZED,
+		Json(json!({
+			"error": "missing or invalid bearer token"
+		})),
+	)
+		.into_response();
+	response
+		.headers_mut()
+		.insert(header::WWW_AUTHENTICATE, HeaderValue::from_static("Bearer"));
+	response
+}
+
+fn bearer_token(headers: &HeaderMap) -> Option<&str> {
+	let value = headers.get(header::AUTHORIZATION)?.to_str().ok()?.trim();
+	let (scheme, token) = value.split_once(' ')?;
+	if !scheme.eq_ignore_ascii_case("Bearer") {
+		return None;
+	}
+	let token = token.trim();
+	if token.is_empty() {
+		None
+	} else {
+		Some(token)
+	}
+}
+
+fn parse_api_keys(value: &str) -> Vec<String> {
+	value
+		.split(',')
+		.map(str::trim)
+		.filter(|key| !key.is_empty())
+		.map(str::to_string)
+		.collect()
+}
+
+fn parse_bool(value: &str) -> Option<bool> {
+	match value.trim().to_ascii_lowercase().as_str() {
+		"1" | "true" | "yes" | "on" => Some(true),
+		"0" | "false" | "no" | "off" => Some(false),
+		_ => None,
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use axum::body::to_bytes;
+	use axum::http::Request;
+	use axum::middleware;
+	use axum::routing::get;
+	use axum::Router;
+	use tower::ServiceExt;
+
+	async fn ok() -> &'static str {
+		"ok"
+	}
+
+	fn protected_app(config: BearerAuthConfig) -> Router {
+		Router::new()
+			.route("/protected", get(ok))
+			.layer(middleware::from_fn_with_state(config, require_bearer_auth))
+	}
+
+	#[tokio::test]
+	async fn disabled_auth_allows_missing_header() {
+		let response = protected_app(BearerAuthConfig::disabled())
+			.oneshot(
+				Request::builder()
+					.uri("/protected")
+					.body(Body::empty())
+					.unwrap(),
+			)
+			.await
+			.unwrap();
+
+		assert_eq!(response.status(), StatusCode::OK);
+	}
+
+	#[tokio::test]
+	async fn required_auth_rejects_missing_header() {
+		let response = protected_app(BearerAuthConfig::required(["secret"]))
+			.oneshot(
+				Request::builder()
+					.uri("/protected")
+					.body(Body::empty())
+					.unwrap(),
+			)
+			.await
+			.unwrap();
+
+		assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+		assert_eq!(
+			response.headers().get(header::WWW_AUTHENTICATE).unwrap(),
+			"Bearer"
+		);
+	}
+
+	#[tokio::test]
+	async fn required_auth_rejects_invalid_bearer_token() {
+		let response = protected_app(BearerAuthConfig::required(["secret"]))
+			.oneshot(
+				Request::builder()
+					.uri("/protected")
+					.header(header::AUTHORIZATION, "Bearer wrong")
+					.body(Body::empty())
+					.unwrap(),
+			)
+			.await
+			.unwrap();
+
+		assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+	}
+
+	#[tokio::test]
+	async fn required_auth_accepts_valid_bearer_token() {
+		let response = protected_app(BearerAuthConfig::required(["secret"]))
+			.oneshot(
+				Request::builder()
+					.uri("/protected")
+					.header(header::AUTHORIZATION, "Bearer secret")
+					.body(Body::empty())
+					.unwrap(),
+			)
+			.await
+			.unwrap();
+
+		assert_eq!(response.status(), StatusCode::OK);
+		let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+		assert_eq!(&body[..], b"ok");
+	}
+
+	#[test]
+	fn api_keys_are_comma_separated_and_trimmed() {
+		assert_eq!(
+			parse_api_keys(" first,second ,, third "),
+			vec!["first", "second", "third"]
+		);
+	}
+}

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -5,73 +5,72 @@ use axum::middleware::Next;
 use axum::response::{IntoResponse, Response};
 use axum::Json;
 use serde_json::json;
+use std::sync::Arc;
 
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct BearerAuthConfig {
-	required: bool,
-	allowed_api_keys: Vec<String>,
-}
+use crate::context::Context;
+use crate::db::DB;
 
-impl BearerAuthConfig {
-	pub fn from_env() -> Self {
-		let allowed_api_keys = std::env::var("PUPPYLOG_API_KEYS")
-			.ok()
-			.map(|value| parse_api_keys(&value))
-			.unwrap_or_default();
-		let required = std::env::var("PUPPYLOG_AUTH_REQUIRED")
-			.ok()
-			.and_then(|value| parse_bool(&value))
-			.unwrap_or(!allowed_api_keys.is_empty());
-
-		Self {
-			required,
-			allowed_api_keys,
-		}
-	}
-
-	#[cfg(test)]
-	pub fn disabled() -> Self {
-		Self {
-			required: false,
-			allowed_api_keys: Vec::new(),
-		}
-	}
-
-	#[cfg(test)]
-	pub fn required<I, S>(allowed_api_keys: I) -> Self
-	where
-		I: IntoIterator<Item = S>,
-		S: Into<String>,
-	{
-		Self {
-			required: true,
-			allowed_api_keys: allowed_api_keys.into_iter().map(Into::into).collect(),
-		}
-	}
-
-	fn allows(&self, headers: &HeaderMap) -> bool {
-		if !self.required {
-			return true;
-		}
-
-		let Some(token) = bearer_token(headers) else {
-			return false;
-		};
-
-		self.allowed_api_keys.iter().any(|key| key == token)
-	}
-}
+const BOOTSTRAP_ADMIN_NAME: &str = "PUPPYLOG_BOOTSTRAP_ADMIN_NAME";
+const BOOTSTRAP_ADMIN_API_KEY: &str = "PUPPYLOG_BOOTSTRAP_ADMIN_API_KEY";
 
 pub async fn require_bearer_auth(
-	State(config): State<BearerAuthConfig>,
+	State(ctx): State<Arc<Context>>,
 	headers: HeaderMap,
-	request: Request<Body>,
+	mut request: Request<Body>,
 	next: Next,
 ) -> Response {
-	if config.allows(&headers) {
-		return next.run(request).await;
+	let Some(token) = bearer_token(&headers) else {
+		return unauthorized_response();
+	};
+
+	match ctx.db.authenticate_api_key(token).await {
+		Ok(Some(user)) => {
+			request.extensions_mut().insert(user);
+			next.run(request).await
+		}
+		Ok(None) => unauthorized_response(),
+		Err(err) => {
+			log::error!("failed to authenticate bearer token: {err}");
+			(
+				StatusCode::INTERNAL_SERVER_ERROR,
+				Json(json!({
+					"error": "failed to authenticate bearer token"
+				})),
+			)
+				.into_response()
+		}
+	}
+}
+
+pub async fn bootstrap_admin_from_env(db: &DB) -> anyhow::Result<()> {
+	let name = std::env::var(BOOTSTRAP_ADMIN_NAME).ok();
+	let api_key = std::env::var(BOOTSTRAP_ADMIN_API_KEY).ok();
+
+	let (Some(name), Some(api_key)) = (name, api_key) else {
+		if std::env::var(BOOTSTRAP_ADMIN_NAME).is_ok()
+			|| std::env::var(BOOTSTRAP_ADMIN_API_KEY).is_ok()
+		{
+			anyhow::bail!(
+				"{BOOTSTRAP_ADMIN_NAME} and {BOOTSTRAP_ADMIN_API_KEY} must be set together"
+			);
+		}
+		return Ok(());
+	};
+
+	let name = name.trim();
+	let api_key = api_key.trim();
+	if name.is_empty() || api_key.is_empty() {
+		anyhow::bail!("{BOOTSTRAP_ADMIN_NAME} and {BOOTSTRAP_ADMIN_API_KEY} must not be empty");
 	}
 
+	match db.bootstrap_admin(name, api_key).await? {
+		Some(user) => log::info!("created bootstrap admin user '{}'", user.name),
+		None => log::info!("bootstrap admin skipped because users already exist"),
+	}
+	Ok(())
+}
+
+fn unauthorized_response() -> Response {
 	let mut response = (
 		StatusCode::UNAUTHORIZED,
 		Json(json!({
@@ -99,61 +98,49 @@ fn bearer_token(headers: &HeaderMap) -> Option<&str> {
 	}
 }
 
-fn parse_api_keys(value: &str) -> Vec<String> {
-	value
-		.split(',')
-		.map(str::trim)
-		.filter(|key| !key.is_empty())
-		.map(str::to_string)
-		.collect()
-}
-
-fn parse_bool(value: &str) -> Option<bool> {
-	match value.trim().to_ascii_lowercase().as_str() {
-		"1" | "true" | "yes" | "on" => Some(true),
-		"0" | "false" | "no" | "off" => Some(false),
-		_ => None,
-	}
-}
-
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use crate::db::User;
 	use axum::body::to_bytes;
 	use axum::http::Request;
 	use axum::middleware;
 	use axum::routing::get;
+	use axum::Extension;
 	use axum::Router;
+	use tempfile::TempDir;
 	use tower::ServiceExt;
 
 	async fn ok() -> &'static str {
 		"ok"
 	}
 
-	fn protected_app(config: BearerAuthConfig) -> Router {
+	async fn current_user(Extension(user): Extension<User>) -> Json<serde_json::Value> {
+		Json(json!({
+			"id": user.id,
+			"name": user.name,
+			"isAdmin": user.is_admin
+		}))
+	}
+
+	async fn test_context() -> (TempDir, Arc<Context>) {
+		let dir = TempDir::new().unwrap();
+		let log_dir = dir.path().join("logs");
+		std::fs::create_dir_all(&log_dir).unwrap();
+		(dir, Arc::new(Context::new(log_dir).await))
+	}
+
+	fn protected_app(ctx: Arc<Context>) -> Router {
 		Router::new()
 			.route("/protected", get(ok))
-			.layer(middleware::from_fn_with_state(config, require_bearer_auth))
+			.route("/whoami", get(current_user))
+			.layer(middleware::from_fn_with_state(ctx, require_bearer_auth))
 	}
 
 	#[tokio::test]
-	async fn disabled_auth_allows_missing_header() {
-		let response = protected_app(BearerAuthConfig::disabled())
-			.oneshot(
-				Request::builder()
-					.uri("/protected")
-					.body(Body::empty())
-					.unwrap(),
-			)
-			.await
-			.unwrap();
-
-		assert_eq!(response.status(), StatusCode::OK);
-	}
-
-	#[tokio::test]
-	async fn required_auth_rejects_missing_header() {
-		let response = protected_app(BearerAuthConfig::required(["secret"]))
+	async fn rejects_missing_header() {
+		let (_dir, ctx) = test_context().await;
+		let response = protected_app(ctx)
 			.oneshot(
 				Request::builder()
 					.uri("/protected")
@@ -171,8 +158,14 @@ mod tests {
 	}
 
 	#[tokio::test]
-	async fn required_auth_rejects_invalid_bearer_token() {
-		let response = protected_app(BearerAuthConfig::required(["secret"]))
+	async fn rejects_invalid_bearer_token() {
+		let (_dir, ctx) = test_context().await;
+		ctx.db
+			.create_user_with_api_key("admin", true, Some("test"), "secret")
+			.await
+			.unwrap();
+
+		let response = protected_app(ctx)
 			.oneshot(
 				Request::builder()
 					.uri("/protected")
@@ -187,8 +180,14 @@ mod tests {
 	}
 
 	#[tokio::test]
-	async fn required_auth_accepts_valid_bearer_token() {
-		let response = protected_app(BearerAuthConfig::required(["secret"]))
+	async fn accepts_valid_bearer_token() {
+		let (_dir, ctx) = test_context().await;
+		ctx.db
+			.create_user_with_api_key("admin", true, Some("test"), "secret")
+			.await
+			.unwrap();
+
+		let response = protected_app(ctx)
 			.oneshot(
 				Request::builder()
 					.uri("/protected")
@@ -204,11 +203,31 @@ mod tests {
 		assert_eq!(&body[..], b"ok");
 	}
 
-	#[test]
-	fn api_keys_are_comma_separated_and_trimmed() {
-		assert_eq!(
-			parse_api_keys(" first,second ,, third "),
-			vec!["first", "second", "third"]
-		);
+	#[tokio::test]
+	async fn exposes_authenticated_user_to_handlers() {
+		let (_dir, ctx) = test_context().await;
+		let user = ctx
+			.db
+			.create_user_with_api_key("admin", true, Some("test"), "secret")
+			.await
+			.unwrap();
+
+		let response = protected_app(ctx)
+			.oneshot(
+				Request::builder()
+					.uri("/whoami")
+					.header(header::AUTHORIZATION, "Bearer secret")
+					.body(Body::empty())
+					.unwrap(),
+			)
+			.await
+			.unwrap();
+
+		assert_eq!(response.status(), StatusCode::OK);
+		let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+		let payload: serde_json::Value = serde_json::from_slice(&body).unwrap();
+		assert_eq!(payload["id"], user.id);
+		assert_eq!(payload["name"], "admin");
+		assert_eq!(payload["isAdmin"], true);
 	}
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -14,9 +14,12 @@ use diesel::sqlite::{Sqlite, SqliteConnection};
 use diesel::{insert_into, insert_or_ignore_into};
 use puppylog::{LogLevel, Prop};
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 
 use crate::config::db_path;
-use crate::schema::{device_props, devices, log_segments, migrations, segment_props};
+use crate::schema::{
+	api_keys, device_props, devices, log_segments, migrations, segment_props, users,
+};
 use crate::segment::SegmentMeta;
 use crate::types::{GetSegmentsQuery, SortDir};
 
@@ -85,6 +88,28 @@ const MIGRATIONS: &[Migration] = &[
 		sql: r#"
                         ALTER TABLE log_segments ADD COLUMN device_id TEXT;
                         CREATE INDEX IF NOT EXISTS log_segments_device_id_idx ON log_segments(device_id);
+                "#,
+	},
+	Migration {
+		id: 20260429,
+		name: "users_and_api_keys",
+		sql: r#"
+                        CREATE TABLE users (
+                                id INTEGER PRIMARY KEY,
+                                name TEXT NOT NULL UNIQUE,
+                                is_admin BOOLEAN NOT NULL DEFAULT false,
+                                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                        );
+                        CREATE TABLE api_keys (
+                                id INTEGER PRIMARY KEY,
+                                user_id INTEGER NOT NULL,
+                                name TEXT,
+                                key_hash TEXT NOT NULL UNIQUE,
+                                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                                last_used_at TIMESTAMP,
+                                FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+                        );
+                        CREATE INDEX IF NOT EXISTS api_keys_user_id_idx ON api_keys(user_id);
                 "#,
 	},
 ];
@@ -168,6 +193,34 @@ struct DeviceRow {
 	created_at: NaiveDateTime,
 	last_upload_at: Option<NaiveDateTime>,
 	send_interval: i32,
+}
+
+#[derive(Queryable, Debug)]
+#[diesel(table_name = users)]
+struct UserRow {
+	id: i32,
+	name: String,
+	is_admin: bool,
+	created_at: NaiveDateTime,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct User {
+	pub id: i32,
+	pub name: String,
+	pub is_admin: bool,
+}
+
+impl From<UserRow> for User {
+	fn from(row: UserRow) -> Self {
+		let _created_at = row.created_at;
+		User {
+			id: row.id,
+			name: row.name,
+			is_admin: row.is_admin,
+		}
+	}
 }
 
 #[derive(Queryable, Debug)]
@@ -284,6 +337,109 @@ impl DB {
 		self.read_pool
 			.get()
 			.context("failed to get sqlite read connection from pool")
+	}
+
+	pub async fn create_user(&self, name: &str, is_admin: bool) -> Result<User> {
+		let mut conn = self.conn()?;
+		conn.transaction::<_, diesel::result::Error, _>(|conn| {
+			insert_into(users::table)
+				.values((users::name.eq(name), users::is_admin.eq(is_admin)))
+				.execute(conn)?;
+			let row: UserRow = users::table
+				.filter(users::id.eq(last_insert_id(conn)? as i32))
+				.first(conn)?;
+			Ok(User::from(row))
+		})
+		.map_err(Into::into)
+	}
+
+	pub async fn add_api_key(&self, user_id: i32, name: Option<&str>, api_key: &str) -> Result<()> {
+		let mut conn = self.conn()?;
+		insert_into(api_keys::table)
+			.values((
+				api_keys::user_id.eq(user_id),
+				api_keys::name.eq(name),
+				api_keys::key_hash.eq(hash_api_key(api_key)),
+			))
+			.execute(&mut conn)
+			.context("failed to create api key")?;
+		Ok(())
+	}
+
+	pub async fn create_user_with_api_key(
+		&self,
+		name: &str,
+		is_admin: bool,
+		key_name: Option<&str>,
+		api_key: &str,
+	) -> Result<User> {
+		let mut conn = self.conn()?;
+		conn.transaction::<_, diesel::result::Error, _>(|conn| {
+			insert_into(users::table)
+				.values((users::name.eq(name), users::is_admin.eq(is_admin)))
+				.execute(conn)?;
+			let user_id = last_insert_id(conn)? as i32;
+			insert_into(api_keys::table)
+				.values((
+					api_keys::user_id.eq(user_id),
+					api_keys::name.eq(key_name),
+					api_keys::key_hash.eq(hash_api_key(api_key)),
+				))
+				.execute(conn)?;
+			let row: UserRow = users::table.filter(users::id.eq(user_id)).first(conn)?;
+			Ok(User::from(row))
+		})
+		.map_err(Into::into)
+	}
+
+	pub async fn bootstrap_admin(&self, name: &str, api_key: &str) -> Result<Option<User>> {
+		let mut conn = self.conn()?;
+		conn.transaction::<_, diesel::result::Error, _>(|conn| {
+			let user_count: i64 = users::table.count().get_result(conn)?;
+			let admin_count: i64 = users::table
+				.filter(users::is_admin.eq(true))
+				.count()
+				.get_result(conn)?;
+			if user_count > 0 || admin_count > 0 {
+				return Ok(None);
+			}
+
+			insert_into(users::table)
+				.values((users::name.eq(name), users::is_admin.eq(true)))
+				.execute(conn)?;
+			let user_id = last_insert_id(conn)? as i32;
+			insert_into(api_keys::table)
+				.values((
+					api_keys::user_id.eq(user_id),
+					api_keys::name.eq(Some("bootstrap")),
+					api_keys::key_hash.eq(hash_api_key(api_key)),
+				))
+				.execute(conn)?;
+			let row: UserRow = users::table.filter(users::id.eq(user_id)).first(conn)?;
+			Ok(Some(User::from(row)))
+		})
+		.map_err(Into::into)
+	}
+
+	pub async fn authenticate_api_key(&self, api_key: &str) -> Result<Option<User>> {
+		let key_hash = hash_api_key(api_key);
+		let mut conn = self.conn()?;
+		let row = users::table
+			.inner_join(api_keys::table)
+			.filter(api_keys::key_hash.eq(&key_hash))
+			.select((users::id, users::name, users::is_admin, users::created_at))
+			.first::<UserRow>(&mut conn)
+			.optional()
+			.context("failed to authenticate api key")?;
+
+		if row.is_some() {
+			diesel::update(api_keys::table.filter(api_keys::key_hash.eq(key_hash)))
+				.set(api_keys::last_used_at.eq(Some(Utc::now().naive_utc())))
+				.execute(&mut conn)
+				.context("failed to update api key last_used_at")?;
+		}
+
+		Ok(row.map(User::from))
 	}
 
 	pub async fn update_device_stats(
@@ -749,6 +905,17 @@ struct LastInsertRow {
 	id: i64,
 }
 
+fn last_insert_id(conn: &mut SqliteConnection) -> diesel::result::QueryResult<i64> {
+	diesel::sql_query("SELECT last_insert_rowid() as id")
+		.get_result::<LastInsertRow>(conn)
+		.map(|row| row.id)
+}
+
+fn hash_api_key(api_key: &str) -> String {
+	let digest = Sha256::digest(api_key.as_bytes());
+	digest.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
 fn load_device_metadata(conn: &mut SqliteConnection, device_id: &str) -> Result<Vec<MetaProp>> {
 	let rows: Vec<(String, String)> = device_props::table
 		.filter(device_props::device_id.eq(device_id))
@@ -815,6 +982,86 @@ mod tests {
 			write_pool: pool.clone(),
 			read_pool: pool,
 		})
+	}
+
+	#[tokio::test]
+	async fn bootstrap_creates_first_admin() {
+		let db = test_db();
+
+		let user = db
+			.bootstrap_admin("admin", "secret")
+			.await
+			.unwrap()
+			.expect("admin should be created");
+
+		assert_eq!(user.name, "admin");
+		assert!(user.is_admin);
+		assert_eq!(
+			db.authenticate_api_key("secret").await.unwrap(),
+			Some(user.clone())
+		);
+	}
+
+	#[tokio::test]
+	async fn bootstrap_does_not_overwrite_existing_admin() {
+		let db = test_db();
+		let existing = db
+			.create_user_with_api_key("existing", true, Some("existing"), "old-secret")
+			.await
+			.unwrap();
+
+		assert!(db
+			.bootstrap_admin("new-admin", "new-secret")
+			.await
+			.unwrap()
+			.is_none());
+		assert_eq!(
+			db.authenticate_api_key("old-secret").await.unwrap(),
+			Some(existing)
+		);
+		assert_eq!(db.authenticate_api_key("new-secret").await.unwrap(), None);
+	}
+
+	#[tokio::test]
+	async fn bootstrap_does_not_overwrite_existing_user() {
+		let db = test_db();
+		let existing = db
+			.create_user_with_api_key("user", false, Some("user"), "old-secret")
+			.await
+			.unwrap();
+
+		assert!(db
+			.bootstrap_admin("admin", "new-secret")
+			.await
+			.unwrap()
+			.is_none());
+		assert_eq!(
+			db.authenticate_api_key("old-secret").await.unwrap(),
+			Some(existing)
+		);
+		assert_eq!(db.authenticate_api_key("new-secret").await.unwrap(), None);
+	}
+
+	#[tokio::test]
+	async fn user_can_have_multiple_api_keys() {
+		let db = test_db();
+		let user = db.create_user("admin", true).await.unwrap();
+		db.add_api_key(user.id, Some("first"), "first-secret")
+			.await
+			.unwrap();
+		db.add_api_key(user.id, Some("second"), "second-secret")
+			.await
+			.unwrap();
+
+		assert_eq!(
+			db.authenticate_api_key("first-secret").await.unwrap(),
+			Some(user.clone())
+		);
+		assert_eq!(
+			db.authenticate_api_key("second-secret").await.unwrap(),
+			Some(user)
+		);
+		assert_eq!(db.authenticate_api_key("wrong").await.unwrap(), None);
 	}
 
 	#[tokio::test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,6 @@
+use auth::BearerAuthConfig;
 use axum::extract::DefaultBodyLimit;
+use axum::middleware;
 use axum::routing::{delete, get, post};
 use axum::Router;
 use config::log_path;
@@ -10,6 +12,7 @@ use tower_http::compression::CompressionLayer;
 use tower_http::cors::{AllowMethods, Any, CorsLayer};
 use tower_http::decompression::RequestDecompressionLayer;
 
+mod auth;
 mod cache;
 mod cleanup;
 mod config;
@@ -60,92 +63,68 @@ async fn main() {
 		ctx.clone(),
 	));
 
+	let app = build_router(ctx, BearerAuthConfig::from_env());
+
+	// run our app with hyper, listening globally on port 3000
+	let listener = tokio::net::TcpListener::bind("0.0.0.0:3337").await.unwrap();
+	axum::serve(listener, app).await.unwrap();
+}
+
+fn build_router(ctx: Arc<Context>, auth_config: BearerAuthConfig) -> Router {
 	let cors = CorsLayer::new()
-		.allow_origin(Any) // Allow requests from any origin
-		.allow_methods(AllowMethods::any()) // Allowed HTTP methods
+		.allow_origin(Any)
+		.allow_methods(AllowMethods::any())
 		.allow_headers(Any);
 
-	// build our application with a route
-	let app = Router::new()
-		.route("/", get(controllers::root))
-		.route("/puppylog.js", get(controllers::js))
-		.route("/puppylog.css", get(controllers::css))
-		.route("/favicon.ico", get(controllers::favicon))
-		.route("/favicon-192x192.png", get(controllers::favicon_192x192))
-		.route("/favicon-512x512.png", get(controllers::favicon_512x512))
-		.route("/manifest.json", get(controllers::manifest))
+	let protected_routes = Router::new()
 		.route("/api/logs", get(controllers::get_logs))
-		.layer(CompressionLayer::new())
-		.layer(cors.clone())
 		.route("/api/logs/stream", get(controllers::stream_logs))
-		.layer(cors.clone())
 		.route(
 			"/api/settings/query",
 			post(controllers::post_settings_query),
 		)
-		.with_state(ctx.clone())
 		.route("/api/settings/query", get(controllers::get_settings_query))
-		.with_state(ctx.clone())
 		.route("/api/segments", get(controllers::get_segments))
-		.with_state(ctx.clone())
 		.route(
 			"/api/segment/metadata",
 			get(controllers::get_segment_metadata),
 		)
-		.with_state(ctx.clone())
 		.route("/api/v1/validate_query", get(controllers::validate_query))
 		.route("/api/v1/logs/stream", get(controllers::stream_logs))
-		.layer(cors.clone())
 		.route("/api/v1/logs/histogram", get(controllers::get_histogram))
-		.layer(cors.clone())
 		.route(
 			"/api/v1/device/{deviceId}/status",
 			get(controllers::get_device_status),
 		)
-		.layer(cors.clone())
-		.with_state(ctx.clone())
 		.route("/api/v1/device/{deviceId}", get(controllers::get_device))
-		.with_state(ctx.clone())
 		.route(
 			"/api/v1/device/{deviceId}/logs",
 			post(controllers::upload_device_logs),
 		)
-		.layer(cors.clone())
 		.layer(DefaultBodyLimit::max(1024 * 1024 * 1000))
 		.layer(RequestDecompressionLayer::new().gzip(true).zstd(true))
-		.with_state(ctx.clone())
 		.route(
 			"/api/v1/device/{deviceId}/metadata",
 			post(controllers::update_device_metadata),
 		)
-		.with_state(ctx.clone())
 		.route(
 			"/api/v1/device/{deviceId}/settings",
 			post(controllers::update_device_settings),
 		)
-		.with_state(ctx.clone())
 		.route("/api/v1/device_bulkedit", post(controllers::bulk_edit))
-		.with_state(ctx.clone())
 		.route("/api/v1/settings", post(controllers::post_settings_query))
-		.with_state(ctx.clone())
 		.route("/api/v1/settings", get(controllers::get_settings_query))
-		.with_state(ctx.clone())
 		.route("/api/v1/devices", get(controllers::get_devices))
-		.with_state(ctx.clone())
 		.route("/api/v1/segments", get(controllers::get_segments))
-		.with_state(ctx.clone())
 		.route("/api/v1/segment/{segmentId}", get(controllers::get_segment))
-		.with_state(ctx.clone())
 		.route(
 			"/api/v1/segment/{segmentId}/logs.txt",
 			get(controllers::download_segment_text),
 		)
-		.with_state(ctx.clone())
 		.route(
 			"/api/v1/segment/{segmentId}/props",
 			get(controllers::get_segment_props),
 		)
-		.with_state(ctx.clone())
 		.route(
 			"/api/v1/segment/{segmentId}/download",
 			get(controllers::download_segment),
@@ -154,13 +133,112 @@ async fn main() {
 			"/api/v1/segment/{segmentId}",
 			delete(controllers::delete_segment),
 		)
-		.with_state(ctx.clone())
-		.route("/api/v1/server_info", get(controllers::get_server_info))
 		.route("/api/v1/server/cleanup", post(controllers::start_cleanup))
-		.with_state(ctx.clone())
-		.fallback(get(controllers::root));
+		.route_layer(middleware::from_fn_with_state(
+			auth_config,
+			auth::require_bearer_auth,
+		))
+		.with_state(ctx);
 
-	// run our app with hyper, listening globally on port 3000
-	let listener = tokio::net::TcpListener::bind("0.0.0.0:3337").await.unwrap();
-	axum::serve(listener, app).await.unwrap();
+	Router::new()
+		.route("/", get(controllers::root))
+		.route("/puppylog.js", get(controllers::js))
+		.route("/puppylog.css", get(controllers::css))
+		.route("/favicon.ico", get(controllers::favicon))
+		.route("/favicon-192x192.png", get(controllers::favicon_192x192))
+		.route("/favicon-512x512.png", get(controllers::favicon_512x512))
+		.route("/manifest.json", get(controllers::manifest))
+		.route("/api/v1/server_info", get(controllers::get_server_info))
+		.merge(protected_routes)
+		.fallback(get(controllers::root))
+		.layer(CompressionLayer::new())
+		.layer(cors)
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use axum::body::Body;
+	use axum::http::{header, Request, StatusCode};
+	use serial_test::serial;
+	use tempfile::TempDir;
+	use tower::ServiceExt;
+
+	async fn test_app(auth_config: BearerAuthConfig) -> (TempDir, Router) {
+		let dir = TempDir::new().unwrap();
+		let log_dir = dir.path().join("logs");
+		std::fs::create_dir_all(&log_dir).unwrap();
+		std::env::set_var("LOG_PATH", &log_dir);
+		std::env::set_var("DB_PATH", dir.path().join("db.sqlite"));
+		std::env::set_var("SETTINGS_PATH", dir.path().join("settings.json"));
+		std::env::set_var("UPLOAD_PATH", dir.path().join("uploads"));
+		std::fs::write(
+			dir.path().join("settings.json"),
+			"{\"collection_query\":\"\"}",
+		)
+		.unwrap();
+
+		let ctx = Arc::new(Context::new(log_dir).await);
+		let app = build_router(ctx, auth_config);
+		(dir, app)
+	}
+
+	#[tokio::test]
+	#[serial]
+	async fn protected_api_rejects_missing_bearer_token() {
+		let (_dir, app) = test_app(BearerAuthConfig::required(["secret"])).await;
+
+		let response = app
+			.oneshot(
+				Request::builder()
+					.uri("/api/v1/validate_query?query=level%20=%20info")
+					.body(Body::empty())
+					.unwrap(),
+			)
+			.await
+			.unwrap();
+
+		assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+		assert_eq!(
+			response.headers().get(header::WWW_AUTHENTICATE).unwrap(),
+			"Bearer"
+		);
+	}
+
+	#[tokio::test]
+	#[serial]
+	async fn protected_api_accepts_valid_bearer_token() {
+		let (_dir, app) = test_app(BearerAuthConfig::required(["secret"])).await;
+
+		let response = app
+			.oneshot(
+				Request::builder()
+					.uri("/api/v1/validate_query?query=level%20=%20info")
+					.header(header::AUTHORIZATION, "Bearer secret")
+					.body(Body::empty())
+					.unwrap(),
+			)
+			.await
+			.unwrap();
+
+		assert_eq!(response.status(), StatusCode::OK);
+	}
+
+	#[tokio::test]
+	#[serial]
+	async fn server_info_stays_public_with_auth_required() {
+		let (_dir, app) = test_app(BearerAuthConfig::required(["secret"])).await;
+
+		let response = app
+			.oneshot(
+				Request::builder()
+					.uri("/api/v1/server_info")
+					.body(Body::empty())
+					.unwrap(),
+			)
+			.await
+			.unwrap();
+
+		assert_eq!(response.status(), StatusCode::OK);
+	}
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,3 @@
-use auth::BearerAuthConfig;
 use axum::extract::DefaultBodyLimit;
 use axum::middleware;
 use axum::routing::{delete, get, post};
@@ -53,6 +52,9 @@ async fn main() {
 		}
 	}
 	let ctx = Arc::new(ctx);
+	auth::bootstrap_admin_from_env(&ctx.db)
+		.await
+		.expect("failed to bootstrap admin user");
 
 	tokio::spawn(upload::process_log_uploads(ctx.clone()));
 	if std::env::var("DISK_SPACE_MONITOR").as_deref() == Ok("1") {
@@ -63,14 +65,14 @@ async fn main() {
 		ctx.clone(),
 	));
 
-	let app = build_router(ctx, BearerAuthConfig::from_env());
+	let app = build_router(ctx);
 
 	// run our app with hyper, listening globally on port 3000
 	let listener = tokio::net::TcpListener::bind("0.0.0.0:3337").await.unwrap();
 	axum::serve(listener, app).await.unwrap();
 }
 
-fn build_router(ctx: Arc<Context>, auth_config: BearerAuthConfig) -> Router {
+fn build_router(ctx: Arc<Context>) -> Router {
 	let cors = CorsLayer::new()
 		.allow_origin(Any)
 		.allow_methods(AllowMethods::any())
@@ -135,7 +137,7 @@ fn build_router(ctx: Arc<Context>, auth_config: BearerAuthConfig) -> Router {
 		)
 		.route("/api/v1/server/cleanup", post(controllers::start_cleanup))
 		.route_layer(middleware::from_fn_with_state(
-			auth_config,
+			ctx.clone(),
 			auth::require_bearer_auth,
 		))
 		.with_state(ctx);
@@ -164,7 +166,7 @@ mod tests {
 	use tempfile::TempDir;
 	use tower::ServiceExt;
 
-	async fn test_app(auth_config: BearerAuthConfig) -> (TempDir, Router) {
+	async fn test_app() -> (TempDir, Arc<Context>, Router) {
 		let dir = TempDir::new().unwrap();
 		let log_dir = dir.path().join("logs");
 		std::fs::create_dir_all(&log_dir).unwrap();
@@ -179,14 +181,14 @@ mod tests {
 		.unwrap();
 
 		let ctx = Arc::new(Context::new(log_dir).await);
-		let app = build_router(ctx, auth_config);
-		(dir, app)
+		let app = build_router(ctx.clone());
+		(dir, ctx, app)
 	}
 
 	#[tokio::test]
 	#[serial]
 	async fn protected_api_rejects_missing_bearer_token() {
-		let (_dir, app) = test_app(BearerAuthConfig::required(["secret"])).await;
+		let (_dir, _ctx, app) = test_app().await;
 
 		let response = app
 			.oneshot(
@@ -208,7 +210,11 @@ mod tests {
 	#[tokio::test]
 	#[serial]
 	async fn protected_api_accepts_valid_bearer_token() {
-		let (_dir, app) = test_app(BearerAuthConfig::required(["secret"])).await;
+		let (_dir, ctx, app) = test_app().await;
+		ctx.db
+			.create_user_with_api_key("admin", true, Some("test"), "secret")
+			.await
+			.unwrap();
 
 		let response = app
 			.oneshot(
@@ -227,7 +233,7 @@ mod tests {
 	#[tokio::test]
 	#[serial]
 	async fn server_info_stays_public_with_auth_required() {
-		let (_dir, app) = test_app(BearerAuthConfig::required(["secret"])).await;
+		let (_dir, _ctx, app) = test_app().await;
 
 		let response = app
 			.oneshot(

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,4 +1,24 @@
 diesel::table! {
+	users (id) {
+		id -> Integer,
+		name -> Text,
+		is_admin -> Bool,
+		created_at -> Timestamp,
+	}
+}
+
+diesel::table! {
+	api_keys (id) {
+		id -> Integer,
+		user_id -> Integer,
+		name -> Nullable<Text>,
+		key_hash -> Text,
+		created_at -> Timestamp,
+		last_used_at -> Nullable<Timestamp>,
+	}
+}
+
+diesel::table! {
 	devices (id) {
 		id -> Text,
 		send_logs -> Bool,
@@ -49,7 +69,11 @@ diesel::table! {
 	}
 }
 
+diesel::joinable!(api_keys -> users (user_id));
+
 diesel::allow_tables_to_appear_in_same_query!(
+	users,
+	api_keys,
 	devices,
 	device_props,
 	log_segments,


### PR DESCRIPTION
## Summary
- add configurable Bearer API key auth for protected API routes
- keep web assets and /api/v1/server_info public
- send plog auth tokens as Bearer tokens
- document PUPPYLOG_API_KEYS / PUPPYLOG_AUTH_REQUIRED

## Tests
- cargo test -p puppylog-server --bin puppylog tests::protected_api_rejects_missing_bearer_token -- --exact --nocapture
- cargo test -p puppylog-server --bin puppylog tests::protected_api_accepts_valid_bearer_token -- --exact --nocapture
- cargo test -p puppylog-server --bin puppylog tests::server_info_stays_public_with_auth_required -- --exact --nocapture
- cargo test -p puppylog-server --bin puppylog auth::tests -- --nocapture
- cargo test -p plog --bin plog